### PR TITLE
createjson: cover every module in -c builder + --init-config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,7 +271,76 @@ whichever backend `RGBMatrix` resolves to (terminal in devcontainer,
 panel on a Pi). **Don't add a new `examples/subway_render_check.rs`** —
 `--preview` is the one place we eyeball renderers.
 
-### 5. Update docs
+### 5. Wire into the interactive builder + starter config — `src/createjson/`
+
+The `-c` interactive flow and the `--init-config <path>` one-shot both
+live under `src/createjson/`. **Both** must learn about a new module,
+otherwise users who go through `-c` (or who download a release binary
+and run `--init-config`) can never enable the tile without
+hand-editing the file.
+
+```
+src/createjson/
+├── mod.rs        # menu + dispatch + `default_config()` starter JSON
+├── subway.rs     # new: per-module `Options` struct + `configure()` prompt
+└── …             # existing one-file-per-module pattern
+```
+
+Pattern from any of `iss.rs` / `flights.rs` / `pihole.rs`:
+
+```rust
+// src/createjson/subway.rs
+use crate::createjson::ui;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SubwayOptions {
+    pub run: bool,
+    pub station_id: String,
+}
+
+impl Default for SubwayOptions {
+    fn default() -> Self { Self { run: true, station_id: "127N".into() } }
+}
+
+pub fn configure() -> Result<SubwayOptions, String> {
+    ui::section("Subway");
+    let station_id = ui::read_required("MTA station id (e.g. 127N)");
+    ui::success(&format!("Subway — {station_id}"));
+    Ok(SubwayOptions { run: true, station_id })
+}
+
+pub fn summary_line(opts: &SubwayOptions) -> String {
+    format!("subway ({})", opts.station_id)
+}
+```
+
+Then in `src/createjson/mod.rs`, four small edits:
+
+1. `pub mod subway;` at the top with the other module declarations.
+2. A new menu entry in `print_menu()` (next free number — keep the
+   numbering consecutive).
+3. A new match arm in `create_json()`:
+   ```rust
+   "N" => match subway::configure() {
+       Ok(opts) => {
+           let label = subway::summary_line(&opts);
+           let value = serde_json::to_value(opts).expect("SubwayOptions serializes");
+           entries.push(Entry { section: "subway", label, value });
+       }
+       Err(e) => ui::error(&format!("subway config failed: {e}")),
+   },
+   ```
+4. Add `"subway"` to the `sections` array used by `fold_section()`.
+
+**Also update `default_config()`** in the same file — its JSON literal
+is what `--init-config` writes. Add a `"subway": {"run":false,
+"station_id":"REPLACE_ME_STATION_ID"}` entry so the starter file lists
+every section. Required keys take `REPLACE_ME_*` placeholders; optional
+keys take their actual defaults. The user only has to flip `run: true`
+and fill placeholders to enable a tile.
+
+### 6. Update docs + `--preview` help
 
 - Add a `# Config` block to the top of `src/lib/matrix/subway.rs` matching the
   format used by every other matrix doc-comment (layout diagram + YAML
@@ -280,8 +349,11 @@ panel on a Pi). **Don't add a new `examples/subway_render_check.rs`** —
   files.
 - Add a row to the `### subway` section of `README.md` if the module is
   user-facing.
+- Append `subway` to the comma-separated list in the `--preview` help
+  text in `src/main.rs` so `--help` reports the full set.
 
-That's the whole recipe. No changes to `main.rs`, no changes to the
+That's the whole recipe. Beyond the `--preview` help-text update,
+no other changes to `main.rs` are needed, and no changes to the
 scheduler.
 
 ---
@@ -425,9 +497,10 @@ scheduler.
 
 | Need to…                              | Edit…                                                                  |
 | ------------------------------------- | ---------------------------------------------------------------------- |
-| Add a new API + matrix                | `src/lib/api/<name>/`, `src/lib/matrix/<name>.rs`, `registry.rs`       |
+| Add a new API + matrix                | `src/lib/api/<name>/`, `src/lib/matrix/<name>.rs`, `registry.rs`, **`src/createjson/<name>.rs` + `createjson/mod.rs`** |
 | Add a new provider to existing module | `src/lib/api/<name>/<provider>.rs` + enum variant in that module's `mod.rs` |
-| Add a new config field                | The section struct in `registry.rs` + all three `examples/configs/*`   |
+| Add a new config field                | The section struct in `registry.rs` + all three `examples/configs/*` + the matching `*Options` struct in `src/createjson/<name>.rs` + the `default_config()` JSON literal in `createjson/mod.rs` |
+| Add the `-c` / `--init-config` prompt | `src/createjson/<name>.rs` (one-file pattern) + register in `createjson/mod.rs` (menu entry, match arm, `sections` array, `default_config()` placeholder) |
 | Change panel geometry                 | `src/main.rs::build_matrix`                                            |
 | Add a new font                        | `src/sh/install.sh` + the renderer's `*Fonts` struct                   |
 | Change a shared HTTP behavior         | `src/lib/api/http.rs`                                                  |

--- a/src/createjson/aurora.rs
+++ b/src/createjson/aurora.rs
@@ -1,0 +1,42 @@
+use crate::createjson::ui;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AuroraOptions {
+    pub run: bool,
+    /// Kp value at which the "AURORA LIKELY" banner appears. 5 matches
+    /// NOAA's G1 minor-storm threshold and the registry default.
+    pub alert_threshold: u8,
+}
+
+impl Default for AuroraOptions {
+    fn default() -> Self {
+        Self {
+            run: true,
+            alert_threshold: 5,
+        }
+    }
+}
+
+pub fn configure() -> Result<AuroraOptions, String> {
+    ui::section("Aurora (Kp index)");
+    ui::hint("NOAA planetary K-index, 0-9. The alert banner trips at or above your threshold.");
+
+    let alert_threshold = loop {
+        let raw = ui::read_line_default("Alert threshold (Kp 0-9)", "5");
+        match raw.trim().parse::<u8>() {
+            Ok(v) if v <= 9 => break v,
+            _ => ui::warn("Expected an integer in 0..=9"),
+        }
+    };
+
+    ui::success(&format!("Aurora — alert at Kp ≥ {alert_threshold}"));
+    Ok(AuroraOptions {
+        run: true,
+        alert_threshold,
+    })
+}
+
+pub fn summary_line(opts: &AuroraOptions) -> String {
+    format!("aurora (alert ≥ Kp {})", opts.alert_threshold)
+}

--- a/src/createjson/flights.rs
+++ b/src/createjson/flights.rs
@@ -1,0 +1,52 @@
+use crate::createjson::iss::read_coord_pub as read_coord;
+use crate::createjson::ui;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FlightsOptions {
+    pub run: bool,
+    pub lat: f64,
+    pub lon: f64,
+    pub radius_km: f32,
+}
+
+impl Default for FlightsOptions {
+    fn default() -> Self {
+        Self {
+            run: true,
+            lat: 40.7128,
+            lon: -74.0060,
+            radius_km: 80.0,
+        }
+    }
+}
+
+pub fn configure() -> Result<FlightsOptions, String> {
+    ui::section("Flights");
+    ui::hint("Aircraft within a circular bbox around your location, via OpenSky (anon).");
+
+    let lat = read_coord("Latitude (degrees, -90..90)", 40.7128, -90.0, 90.0);
+    let lon = read_coord("Longitude (degrees, -180..180)", -74.0060, -180.0, 180.0);
+    let radius_km = loop {
+        let raw = ui::read_line_default("Search radius (km, 1..=500)", "80");
+        match raw.trim().parse::<f32>() {
+            Ok(v) if (1.0..=500.0).contains(&v) => break v,
+            _ => ui::warn("Expected a number in 1..=500"),
+        }
+    };
+
+    ui::success(&format!("Flights — lat={lat:.4}, lon={lon:.4}, radius={radius_km}km"));
+    Ok(FlightsOptions {
+        run: true,
+        lat,
+        lon,
+        radius_km,
+    })
+}
+
+pub fn summary_line(opts: &FlightsOptions) -> String {
+    format!(
+        "flights (lat={:.4}, lon={:.4}, r={}km)",
+        opts.lat, opts.lon, opts.radius_km
+    )
+}

--- a/src/createjson/hass.rs
+++ b/src/createjson/hass.rs
@@ -1,0 +1,104 @@
+use crate::createjson::ui;
+use oledlib::serde_helpers::null_string_as_none;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct HassOptions {
+    pub run: bool,
+    pub base_url: String,
+    pub token: String,
+    pub entity_id: String,
+    #[serde(default, deserialize_with = "null_string_as_none")]
+    pub label: Option<String>,
+    #[serde(default, deserialize_with = "null_string_as_none")]
+    pub alarm_state: Option<String>,
+    pub nominal_color: (u8, u8, u8),
+    pub alarm_color: (u8, u8, u8),
+}
+
+impl Default for HassOptions {
+    fn default() -> Self {
+        Self {
+            run: true,
+            base_url: "http://homeassistant.local:8123".to_owned(),
+            token: String::new(),
+            entity_id: "sensor.kitchen_temp".to_owned(),
+            label: None,
+            alarm_state: None,
+            nominal_color: (120, 220, 120),
+            alarm_color: (255, 60, 60),
+        }
+    }
+}
+
+pub fn configure() -> Result<HassOptions, String> {
+    ui::section("Home Assistant");
+    ui::hint("Renders any HASS entity. Needs base URL + long-lived access token + entity id.");
+
+    let base_url = ui::read_line_default(
+        "Base URL (e.g. http://homeassistant.local:8123)",
+        "http://homeassistant.local:8123",
+    );
+    let token = ui::read_required("HASS long-lived access token");
+    let entity_id = ui::read_required("Entity id (e.g. sensor.kitchen_temp)");
+
+    let label_raw = ui::read_line_default("Display label override (blank = use friendly_name)", "");
+    let label = if label_raw.trim().is_empty() {
+        None
+    } else {
+        Some(label_raw.trim().to_string())
+    };
+
+    let alarm_raw = ui::read_line_default(
+        "Alarm state (case-insensitive; flips to alarm color when matched; blank = no alarm)",
+        "",
+    );
+    let alarm_state = if alarm_raw.trim().is_empty() {
+        None
+    } else {
+        Some(alarm_raw.trim().to_string())
+    };
+
+    let nominal_color = read_rgb("Nominal-state RGB", (120, 220, 120));
+    let alarm_color = read_rgb("Alarm-state RGB", (255, 60, 60));
+
+    ui::success(&format!("HASS — {entity_id} @ {base_url}"));
+    Ok(HassOptions {
+        run: true,
+        base_url: base_url.trim().to_string(),
+        token: token.trim().to_string(),
+        entity_id: entity_id.trim().to_string(),
+        label,
+        alarm_state,
+        nominal_color,
+        alarm_color,
+    })
+}
+
+pub fn summary_line(opts: &HassOptions) -> String {
+    format!("hass ({} @ {})", opts.entity_id, opts.base_url)
+}
+
+/// Re-prompt until three 0..=255 integers parse out of any common
+/// separator (space/comma/slash/semicolon). Used for both the
+/// nominal and alarm color prompts.
+fn read_rgb(label: &str, default: (u8, u8, u8)) -> (u8, u8, u8) {
+    let default_str = format!("{} {} {}", default.0, default.1, default.2);
+    loop {
+        let raw = ui::read_line_default(label, &default_str);
+        let parts: Vec<&str> = raw
+            .split(|c: char| c.is_whitespace() || c == ',' || c == '/' || c == ';')
+            .filter(|p| !p.is_empty())
+            .collect();
+        if parts.len() == 3 {
+            if let (Ok(r), Ok(g), Ok(b)) = (
+                parts[0].parse::<u8>(),
+                parts[1].parse::<u8>(),
+                parts[2].parse::<u8>(),
+            ) {
+                return (r, g, b);
+            }
+        }
+        ui::warn("Expected three integers in 0..=255, e.g. '120 220 120'");
+    }
+}

--- a/src/createjson/iss.rs
+++ b/src/createjson/iss.rs
@@ -1,0 +1,53 @@
+use crate::createjson::ui;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct IssOptions {
+    pub run: bool,
+    pub lat: f64,
+    pub lon: f64,
+}
+
+impl Default for IssOptions {
+    fn default() -> Self {
+        // NYC — matches the example configs so the dev-mode and
+        // starter outputs both pick a plausible default location.
+        Self {
+            run: true,
+            lat: 40.7128,
+            lon: -74.0060,
+        }
+    }
+}
+
+pub fn configure() -> Result<IssOptions, String> {
+    ui::section("ISS");
+    ui::hint("Distance + overhead flag for the International Space Station. Needs your lat/lon.");
+
+    let lat = read_coord("Latitude (degrees, -90..90)", 40.7128, -90.0, 90.0);
+    let lon = read_coord("Longitude (degrees, -180..180)", -74.0060, -180.0, 180.0);
+
+    ui::success(&format!("ISS — lat={lat:.4}, lon={lon:.4}"));
+    Ok(IssOptions { run: true, lat, lon })
+}
+
+pub fn summary_line(opts: &IssOptions) -> String {
+    format!("iss (lat={:.4}, lon={:.4})", opts.lat, opts.lon)
+}
+
+/// Re-prompt until a parseable f64 in `min..=max` is supplied. Shared
+/// with the other lat/lon-bearing modules via a tiny helper rather
+/// than copy-pasting the loop.
+fn read_coord(label: &str, default: f64, min: f64, max: f64) -> f64 {
+    loop {
+        let raw = ui::read_line_default(label, &format!("{default}"));
+        match raw.trim().parse::<f64>() {
+            Ok(v) if (min..=max).contains(&v) => return v,
+            _ => ui::warn(&format!("Expected a number in [{min}, {max}]")),
+        }
+    }
+}
+
+pub(crate) fn read_coord_pub(label: &str, default: f64, min: f64, max: f64) -> f64 {
+    read_coord(label, default, min, max)
+}

--- a/src/createjson/launch.rs
+++ b/src/createjson/launch.rs
@@ -1,0 +1,53 @@
+use crate::createjson::ui;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LaunchOptions {
+    pub run: bool,
+    /// Case-insensitive substring whitelist matched against the
+    /// Launch Library `launch_service_provider.name`. Empty = every
+    /// upcoming launch.
+    pub agency_filter: Vec<String>,
+}
+
+impl Default for LaunchOptions {
+    fn default() -> Self {
+        Self {
+            run: true,
+            agency_filter: Vec::new(),
+        }
+    }
+}
+
+pub fn configure() -> Result<LaunchOptions, String> {
+    ui::section("Launch");
+    ui::hint("Next orbital launch via Launch Library 2. No API key needed.");
+
+    let raw = ui::read_line_default(
+        "Agency filter (comma-separated substrings, blank = all)",
+        "",
+    );
+    let agency_filter: Vec<String> = raw
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    if agency_filter.is_empty() {
+        ui::success("Launch — all providers");
+    } else {
+        ui::success(&format!("Launch — filtering {}", agency_filter.join(", ")));
+    }
+    Ok(LaunchOptions {
+        run: true,
+        agency_filter,
+    })
+}
+
+pub fn summary_line(opts: &LaunchOptions) -> String {
+    if opts.agency_filter.is_empty() {
+        "launch (all agencies)".to_string()
+    } else {
+        format!("launch (filter: {})", opts.agency_filter.join(","))
+    }
+}

--- a/src/createjson/mod.rs
+++ b/src/createjson/mod.rs
@@ -1,5 +1,12 @@
+pub mod aurora;
 pub mod f1;
+pub mod flights;
 pub mod golf;
+pub mod hass;
+pub mod iss;
+pub mod launch;
+pub mod pihole;
+pub mod quake;
 pub mod sport;
 pub mod stock;
 pub mod time;
@@ -60,10 +67,17 @@ fn print_menu(entries: &[Entry]) {
     println!("  {}", ui::bold(&ui::cyan("Modules")));
     println!("    {} Time", ui::bold("[1]"));
     println!("    {} Weather", ui::bold("[2]"));
-    println!("    {} Stock", ui::bold("[3]"));
+    println!("    {} Stock (live + optional historical chart)", ui::bold("[3]"));
     println!("    {} Sport — team (MLB / NBA / NFL / NHL)", ui::bold("[4]"));
     println!("    {} Sport — Golf", ui::bold("[5]"));
     println!("    {} Sport — Formula 1", ui::bold("[6]"));
+    println!("    {} ISS — overhead countdown", ui::bold("[7]"));
+    println!("    {} Earthquake — largest recent USGS event", ui::bold("[8]"));
+    println!("    {} Aurora — NOAA planetary Kp index", ui::bold("[9]"));
+    println!("    {} Flights — nearby aircraft (OpenSky)", ui::bold("[10]"));
+    println!("    {} Launch — next orbital launch countdown", ui::bold("[11]"));
+    println!("    {} Home Assistant entity", ui::bold("[12]"));
+    println!("    {} Pi-hole DNS-block summary", ui::bold("[13]"));
     println!();
     println!("  {}", ui::bold(&ui::cyan("Actions")));
     println!("    {} Matrix panel options", ui::bold("[m]"));
@@ -127,15 +141,24 @@ fn fold_section(values: Vec<Value>) -> Option<Value> {
 /// Non-interactive starter config. Used by `--init-config` so users who
 /// download a release binary get a config they can edit without having to
 /// run the interactive `-c` flow. Time is enabled out of the box (no
-/// external API needed); the other modules are wired in but `run: false`
-/// with `REPLACE_ME_*` placeholders for the keys the user has to fill in.
+/// external API needed); every other module is wired in with `run: false`
+/// and `REPLACE_ME_*` placeholders for any required values, so the user
+/// just has to flip `run` and fill the placeholders for whatever tiles
+/// they want on the panel.
 pub fn default_config() -> Value {
     let json = r#"{
         "matrix_options": {"chain_length":1,"parallel":1,"brightness":50,"oled_slowdown":3,"fail_on_error":false,"hardware_mapping":"adafruit-hat"},
         "time": {"run":true,"color":[255,255,255],"time_format":"null","timezone":"null"},
         "weather": {"run":false,"api":"nws","current_location":true,"current_location_api_key":"REPLACE_ME_IPINFO_TOKEN","weather_format":"imperial","animation":"subtle"},
-        "stock": {"run":false,"api":"finnhub","api_key":"REPLACE_ME_FINNHUB_API_KEY","symbol":"AAPL"},
-        "sport": []
+        "stock": {"run":false,"api":"finnhub","api_key":"REPLACE_ME_FINNHUB_API_KEY","symbol":"AAPL","chart":false},
+        "sport": [],
+        "iss": {"run":false,"lat":40.7128,"lon":-74.0060},
+        "quake": {"run":false,"feed":"significant_day"},
+        "aurora": {"run":false,"alert_threshold":5},
+        "flights": {"run":false,"lat":40.7128,"lon":-74.0060,"radius_km":80.0},
+        "launch": {"run":false,"agency_filter":[]},
+        "hass": {"run":false,"base_url":"http://homeassistant.local:8123","token":"REPLACE_ME_HASS_LONG_LIVED_TOKEN","entity_id":"sensor.kitchen_temp","label":"null","alarm_state":"null","nominal_color":[120,220,120],"alarm_color":[255,60,60]},
+        "pihole": {"run":false,"base_url":"http://pi.hole","token":"null"}
     }"#;
     serde_json::from_str(json).expect("starter config must parse")
 }
@@ -215,6 +238,62 @@ pub fn create_json(dev_mode: bool) -> Value {
                 }
                 Err(e) => ui::error(&format!("f1 config failed: {e}")),
             },
+            "7" => match iss::configure() {
+                Ok(opts) => {
+                    let label = iss::summary_line(&opts);
+                    let value = serde_json::to_value(opts).expect("IssOptions serializes");
+                    entries.push(Entry { section: "iss", label, value });
+                }
+                Err(e) => ui::error(&format!("iss config failed: {e}")),
+            },
+            "8" => match quake::configure() {
+                Ok(opts) => {
+                    let label = quake::summary_line(&opts);
+                    let value = serde_json::to_value(opts).expect("QuakeOptions serializes");
+                    entries.push(Entry { section: "quake", label, value });
+                }
+                Err(e) => ui::error(&format!("quake config failed: {e}")),
+            },
+            "9" => match aurora::configure() {
+                Ok(opts) => {
+                    let label = aurora::summary_line(&opts);
+                    let value = serde_json::to_value(opts).expect("AuroraOptions serializes");
+                    entries.push(Entry { section: "aurora", label, value });
+                }
+                Err(e) => ui::error(&format!("aurora config failed: {e}")),
+            },
+            "10" => match flights::configure() {
+                Ok(opts) => {
+                    let label = flights::summary_line(&opts);
+                    let value = serde_json::to_value(opts).expect("FlightsOptions serializes");
+                    entries.push(Entry { section: "flights", label, value });
+                }
+                Err(e) => ui::error(&format!("flights config failed: {e}")),
+            },
+            "11" => match launch::configure() {
+                Ok(opts) => {
+                    let label = launch::summary_line(&opts);
+                    let value = serde_json::to_value(opts).expect("LaunchOptions serializes");
+                    entries.push(Entry { section: "launch", label, value });
+                }
+                Err(e) => ui::error(&format!("launch config failed: {e}")),
+            },
+            "12" => match hass::configure() {
+                Ok(opts) => {
+                    let label = hass::summary_line(&opts);
+                    let value = serde_json::to_value(opts).expect("HassOptions serializes");
+                    entries.push(Entry { section: "hass", label, value });
+                }
+                Err(e) => ui::error(&format!("hass config failed: {e}")),
+            },
+            "13" => match pihole::configure() {
+                Ok(opts) => {
+                    let label = pihole::summary_line(&opts);
+                    let value = serde_json::to_value(opts).expect("PiholeOptions serializes");
+                    entries.push(Entry { section: "pihole", label, value });
+                }
+                Err(e) => ui::error(&format!("pihole config failed: {e}")),
+            },
             "m" => configure_matrix(&mut matrix_opts),
             "u" => match entries.pop() {
                 Some(e) => ui::success(&format!("Removed: {}", e.label)),
@@ -241,7 +320,10 @@ pub fn create_json(dev_mode: bool) -> Value {
         serde_json::to_value(&matrix_opts).expect("MatrixOptions serializes"),
     );
 
-    let sections = ["time", "weather", "stock", "sport"];
+    let sections = [
+        "time", "weather", "stock", "sport", "iss", "quake", "aurora",
+        "flights", "launch", "hass", "pihole",
+    ];
     for name in sections {
         let bucket: Vec<Value> = entries
             .iter()

--- a/src/createjson/pihole.rs
+++ b/src/createjson/pihole.rs
@@ -1,0 +1,49 @@
+use crate::createjson::ui;
+use oledlib::serde_helpers::null_string_as_none;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PiholeOptions {
+    pub run: bool,
+    pub base_url: String,
+    #[serde(default, deserialize_with = "null_string_as_none")]
+    pub token: Option<String>,
+}
+
+impl Default for PiholeOptions {
+    fn default() -> Self {
+        Self {
+            run: true,
+            base_url: "http://pi.hole".to_owned(),
+            token: None,
+        }
+    }
+}
+
+pub fn configure() -> Result<PiholeOptions, String> {
+    ui::section("Pi-hole");
+    ui::hint("DNS-block summary tile. Token only needed if your admin UI requires auth.");
+
+    let base_url = ui::read_line_default("Base URL (e.g. http://pi.hole)", "http://pi.hole");
+    let token_raw = ui::read_line_default(
+        "Admin API token (blank = unauth — many home installs allow this)",
+        "",
+    );
+    let token = if token_raw.trim().is_empty() {
+        None
+    } else {
+        Some(token_raw.trim().to_string())
+    };
+
+    ui::success(&format!("Pi-hole — {}", base_url));
+    Ok(PiholeOptions {
+        run: true,
+        base_url: base_url.trim().to_string(),
+        token,
+    })
+}
+
+pub fn summary_line(opts: &PiholeOptions) -> String {
+    let auth = if opts.token.is_some() { "auth" } else { "unauth" };
+    format!("pihole ({}, {auth})", opts.base_url)
+}

--- a/src/createjson/quake.rs
+++ b/src/createjson/quake.rs
@@ -1,0 +1,47 @@
+use crate::createjson::ui;
+use oledlib::api::quake::QuakeFeed;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct QuakeOptions {
+    pub run: bool,
+    pub feed: QuakeFeed,
+}
+
+impl Default for QuakeOptions {
+    fn default() -> Self {
+        Self {
+            run: true,
+            feed: QuakeFeed::default(),
+        }
+    }
+}
+
+pub fn configure() -> Result<QuakeOptions, String> {
+    ui::section("Earthquake");
+    ui::hint("USGS feed — pick how chatty you want the tile to be.");
+
+    let slug = ui::choose(
+        "Feed",
+        &[
+            ("significant_day", "Significant events in the last 24h (quietest)"),
+            ("4.5_day", "M ≥ 4.5 in the last 24h"),
+            ("2.5_day", "M ≥ 2.5 in the last 24h"),
+            ("all_day", "Everything in the last 24h (busiest)"),
+        ],
+        "significant_day",
+    );
+    let feed = match slug.as_str() {
+        "4.5_day" => QuakeFeed::M45Day,
+        "2.5_day" => QuakeFeed::M25Day,
+        "all_day" => QuakeFeed::AllDay,
+        _ => QuakeFeed::SignificantDay,
+    };
+
+    ui::success(&format!("Earthquake — feed={}", feed.slug()));
+    Ok(QuakeOptions { run: true, feed })
+}
+
+pub fn summary_line(opts: &QuakeOptions) -> String {
+    format!("quake ({})", opts.feed.slug())
+}

--- a/src/createjson/stock.rs
+++ b/src/createjson/stock.rs
@@ -10,6 +10,11 @@ pub struct StockOptions {
     #[serde(default, deserialize_with = "null_string_as_none")]
     pub api_key: Option<String>,
     pub symbol: String,
+    /// Flips on the historical 1D/1M/1Y line-chart tile in addition
+    /// to the live price tile. Defaults to false so existing configs
+    /// keep parsing unchanged.
+    #[serde(default)]
+    pub chart: bool,
 }
 
 impl Default for StockOptions {
@@ -19,13 +24,21 @@ impl Default for StockOptions {
             api: StockApi::Finnhub,
             api_key: None,
             symbol: "AAPL".to_owned(),
+            chart: false,
         }
     }
 }
 
 fn pick_api() -> StockApi {
-    ui::info("Finnhub is the only supported provider (free tier — register at finnhub.io).");
-    StockApi::Finnhub
+    let slug = ui::choose(
+        "Provider",
+        &[
+            ("finnhub", "Equity tickers — free tier, requires API key"),
+            ("coingecko", "Crypto coin ids — free, no key"),
+        ],
+        "finnhub",
+    );
+    StockApi::str_to_api(slug)
 }
 
 pub fn configure() -> Result<StockOptions, String> {
@@ -33,20 +46,38 @@ pub fn configure() -> Result<StockOptions, String> {
     ui::hint("Polls a single ticker. Add this option again for multiple symbols.");
 
     let api = pick_api();
-    let api_key = ui::read_required("Finnhub API key");
-    let symbol = ui::read_line_default("Ticker symbol (uppercased)", "AAPL")
-        .trim()
-        .to_uppercase();
+    // Finnhub needs an API key; CoinGecko's public tier is unauth.
+    let api_key = match api {
+        StockApi::Finnhub => Some(ui::read_required("Finnhub API key")),
+        StockApi::Coingecko => None,
+    };
+    let symbol_prompt = match api {
+        StockApi::Finnhub => "Ticker symbol (uppercased)",
+        StockApi::Coingecko => "CoinGecko coin id (e.g. bitcoin, ethereum)",
+    };
+    let raw_symbol = ui::read_line_default(symbol_prompt, "AAPL");
+    let symbol = match api {
+        StockApi::Finnhub => raw_symbol.trim().to_uppercase(),
+        StockApi::Coingecko => raw_symbol.trim().to_lowercase(),
+    };
 
-    ui::success(&format!("Stock — {symbol} via {}", api.get_api()));
+    let chart = ui::read_yes_no(
+        "Also enable the 1D/1M/1Y historical chart tile?",
+        false,
+    );
+
+    let chart_tag = if chart { " + chart" } else { "" };
+    ui::success(&format!("Stock — {symbol} via {}{chart_tag}", api.get_api()));
     Ok(StockOptions {
         run: true,
         api,
-        api_key: Some(api_key),
+        api_key,
         symbol,
+        chart,
     })
 }
 
 pub fn summary_line(opts: &StockOptions) -> String {
-    format!("stock: {} ({})", opts.symbol, opts.api.get_api())
+    let chart = if opts.chart { " + chart" } else { "" };
+    format!("stock: {} ({}){}", opts.symbol, opts.api.get_api(), chart)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,7 @@ async fn main() {
             .action(ArgAction::SetTrue),
         Arg::new("preview")
             .long("preview")
-            .help("Render a single screen with built-in fake data and loop forever (no config or network). Names: time, weather, stock, sport, golf, f1, iss")
+            .help("Render a single screen with built-in fake data and loop forever (no config or network). Names: time, weather, stock, stock_chart, sport, golf, f1, iss, quake, aurora, flights, launch, hass, pihole")
             .value_name("NAME"),
         Arg::new("verbose")
             .short('v')


### PR DESCRIPTION
The interactive `-c` flow and the `--init-config <path>` one-shot were stuck on the original six modules (time/weather/stock/sport/golf/f1) and missed everything added since (iss/quake/aurora/flights/launch/ hass/pihole), plus the new `chart: true` field on stock entries.

Adds one createjson submodule per missing section with `configure()` + `summary_line()` following the established pattern; extends the menu to 13 entries; rewrites `default_config()` so the starter file lists every section with run:false + REPLACE_ME_* placeholders for required keys so the user only needs to flip run and fill placeholders. Stock prompt now offers Finnhub vs CoinGecko and asks about the chart tile.

CLAUDE.md recipe gains a new step 5 (wire into createjson) plus a renumbered step 6 (docs + --preview help). "What lives where" table points at createjson for new APIs/matrices and new config fields.