### PR TITLE
v3.5.1: actionable config errors + longer stock_chart dwell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "ohmyoled"
-version = "3.5.0"
+version = "3.5.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1237,6 +1237,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "serde_yml",
  "sunrise",
  "thiserror",
@@ -1726,6 +1727,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "ohmyoled"
-version = "3.5.0"
+version = "3.5.1"
 edition = "2021"
 default-run = "ohmyoled"
 
@@ -21,6 +21,10 @@ image = "0.25"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# Used only at config-load time to wrap the top-level RegistryConfig
+# deserialize so failures include the JSON path that broke (e.g.
+# `stock[2].api: unknown variant 'coingecko'`). Zero deps, ~5 KB.
+serde_path_to_error = "0.1"
 serde_yml = "0.0.12"
 toml = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "gzip"] }

--- a/src/lib/matrix/stock_chart.rs
+++ b/src/lib/matrix/stock_chart.rs
@@ -78,10 +78,13 @@ const MARKER: Color = Color { r: 255, g: 255, b: 255 };
 const NO_DATA: Color = Color { r: 140, g: 140, b: 140 };
 
 const FRAME_TICK: Duration = Duration::from_millis(50);
-const CYCLE: Duration = Duration::from_secs(12);
-/// Frames each period holds before the cycle advances. 4 s × 20 fps
-/// = 80 frames per period.
-const FRAMES_PER_PERIOD: u32 = 80;
+/// 14 s per period × 3 periods = 42 s total. Each period gets a long
+/// enough dwell that the user can actually read the chart, the marquee
+/// can run its two passes, and the eye can settle on the trend.
+const CYCLE: Duration = Duration::from_secs(42);
+/// Frames each period holds before the cycle advances. 14 s × 20 fps
+/// = 280 frames per period.
+const FRAMES_PER_PERIOD: u32 = 280;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Period {
@@ -637,12 +640,19 @@ mod tests {
 
     #[test]
     fn period_rotates_with_frame_index() {
-        // 80 frames per period. Confirm the rotation matches.
+        // Confirm the rotation tracks FRAMES_PER_PERIOD without hard-
+        // coding the value, so future dwell bumps don't require test
+        // edits.
+        let n = FRAMES_PER_PERIOD;
         assert_eq!(Period::from_frame_idx(0), Period::Day);
-        assert_eq!(Period::from_frame_idx(79), Period::Day);
-        assert_eq!(Period::from_frame_idx(80), Period::Month);
-        assert_eq!(Period::from_frame_idx(159), Period::Month);
-        assert_eq!(Period::from_frame_idx(160), Period::Year);
-        assert_eq!(Period::from_frame_idx(240), Period::Day, "wraps after one full cycle");
+        assert_eq!(Period::from_frame_idx(n - 1), Period::Day);
+        assert_eq!(Period::from_frame_idx(n), Period::Month);
+        assert_eq!(Period::from_frame_idx(2 * n - 1), Period::Month);
+        assert_eq!(Period::from_frame_idx(2 * n), Period::Year);
+        assert_eq!(
+            Period::from_frame_idx(3 * n),
+            Period::Day,
+            "wraps after one full cycle"
+        );
     }
 }

--- a/src/lib/serde_helpers.rs
+++ b/src/lib/serde_helpers.rs
@@ -24,21 +24,55 @@ where
 /// Lets each config section be either `"sport": {...}` (single instance, the
 /// legacy shape) or `"sport": [{...}, {...}]` (multiple instances in the same
 /// rotation).
+///
+/// Implemented as a hand-rolled `Visitor` rather than `#[serde(untagged)]`
+/// so the inner deserialize error (e.g. `unknown variant 'coingecko'`)
+/// surfaces directly. The untagged-enum variant tries both shapes and on
+/// failure reports a useless `data did not match any variant of untagged
+/// enum OneOrMany`, which costs hours of bisecting whenever a config
+/// section breaks.
 pub fn one_or_many<'de, T, D>(de: D) -> Result<Vec<T>, D::Error>
 where
     T: Deserialize<'de>,
     D: Deserializer<'de>,
 {
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum OneOrMany<T> {
-        One(T),
-        Many(Vec<T>),
+    use serde::de::{value::MapAccessDeserializer, MapAccess, SeqAccess, Visitor};
+    use std::fmt;
+    use std::marker::PhantomData;
+
+    struct OneOrManyVisitor<T>(PhantomData<fn() -> T>);
+
+    impl<'de, T> Visitor<'de> for OneOrManyVisitor<T>
+    where
+        T: Deserialize<'de>,
+    {
+        type Value = Vec<T>;
+
+        fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            f.write_str("a single object or an array of objects")
+        }
+
+        fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Vec<T>, A::Error> {
+            let mut out = Vec::with_capacity(seq.size_hint().unwrap_or(0));
+            // Manual loop (vs `Vec::<T>::deserialize`) preserves the
+            // element index in the error path — `[2]` lands in the
+            // message instead of being eaten by the inner Vec impl.
+            while let Some(item) = seq.next_element::<T>()? {
+                out.push(item);
+            }
+            Ok(out)
+        }
+
+        fn visit_map<A: MapAccess<'de>>(self, map: A) -> Result<Vec<T>, A::Error> {
+            // Single-object case — forward the same map to T so the
+            // field-level error message (and `serde_path_to_error`
+            // path, when wrapped) reads naturally.
+            let item = T::deserialize(MapAccessDeserializer::new(map))?;
+            Ok(vec![item])
+        }
     }
-    Ok(match OneOrMany::<T>::deserialize(de)? {
-        OneOrMany::One(t) => vec![t],
-        OneOrMany::Many(v) => v,
-    })
+
+    de.deserialize_any(OneOrManyVisitor(PhantomData))
 }
 
 #[cfg(test)]
@@ -73,5 +107,31 @@ mod tests {
     fn missing_defaults_to_empty() {
         let w: Wrap = serde_json::from_str("{}").unwrap();
         assert!(w.items.is_empty());
+    }
+
+    #[test]
+    fn bad_element_surfaces_inner_error() {
+        // Before the visitor rewrite this returned the useless
+        // "data did not match any variant of untagged enum OneOrMany"
+        // message. Now the underlying type error from T comes through.
+        let err = serde_json::from_str::<Wrap>(r#"{"items": [{"id": "not-a-number"}]}"#).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("invalid type") || msg.contains("expected"),
+            "expected a typed-deserialize error, got {msg}"
+        );
+        assert!(
+            !msg.contains("untagged enum OneOrMany"),
+            "OneOrMany wrapper should not appear in error: {msg}"
+        );
+    }
+
+    #[test]
+    fn bad_single_object_surfaces_inner_error() {
+        // Same contract for the single-object path.
+        let err = serde_json::from_str::<Wrap>(r#"{"items": {"id": "not-a-number"}}"#).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("invalid type") || msg.contains("expected"));
+        assert!(!msg.contains("untagged enum OneOrMany"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -204,13 +204,23 @@ async fn main() {
         parse_config_file(&path)
     };
 
-    let parsed: ParsedConfig = serde_json::from_value(configuration.clone()).unwrap_or_else(|e| {
-        println!("Failed to deserialize config: {e}");
-        std::process::exit(33);
-    });
-    let registry_cfg: registry::RegistryConfig =
-        serde_json::from_value(configuration).unwrap_or_else(|e| {
-            println!("Failed to deserialize registry config: {e}");
+    // `serde_path_to_error` wraps the deserialize so failures report
+    // the JSON path that broke (e.g. `stock[2].api: unknown variant
+    // 'coingecko'`). The path is what makes the error actionable;
+    // without it the user has to bisect the config to find the bad
+    // section. Cost is one tiny dep, well worth it.
+    let parsed: ParsedConfig =
+        serde_path_to_error::deserialize(configuration.clone()).unwrap_or_else(|e| {
+            println!("Failed to deserialize config at {}: {}", e.path(), e.inner());
+            std::process::exit(33);
+        });
+    let registry_cfg: registry::RegistryConfig = serde_path_to_error::deserialize(configuration)
+        .unwrap_or_else(|e| {
+            println!(
+                "Failed to deserialize registry config at {}: {}",
+                e.path(),
+                e.inner()
+            );
             std::process::exit(34);
         });
     let dev = std::env::var("DEV").is_ok();


### PR DESCRIPTION
Config-parse failures now report the JSON path that broke. Replaced `one_or_many`'s `#[serde(untagged)]` enum (which swallowed inner errors into a useless "data did not match any variant of untagged enum OneOrMany" line) with a hand-rolled Visitor that surfaces the underlying type/variant error. Wrapped the top-level RegistryConfig
+ ParsedConfig deserialize with `serde_path_to_error` so the message includes the field path:

    stock[2].api: unknown variant `coingecko`, expected `finnhub`
    weather.api: unknown variant `not_a_real_api`, expected one of …
    iss.lat: invalid type: string "forty", expected f64

Also bumps each stock_chart period dwell from 4 s -> 14 s (42 s total cycle): three periods now have enough time for the header marquee to run and for the eye to actually settle on each trend.