### PR TITLE
v3.5.2: visual polish across renderers + hass historical/graph modes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+# Fast feedback for branch work: tests + lint + native build on every
+# push to dev and on PRs targeting main. No artifact uploads, no docker
+# — that's release.yml's job (tags + pushes to main).
+on:
+  push:
+    branches:
+      - dev
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    name: Tests + clippy + build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Cache cargo registry + build dir
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            cargo-${{ runner.os }}-
+
+      # --no-default-features skips the hardware backend (rpi-led-matrix-sys
+      # refuses to build off-Pi); CI doesn't drive panels.
+      - name: cargo build
+        run: cargo build --no-default-features
+
+      - name: cargo test --lib
+        run: cargo test --lib --no-default-features
+
+      - name: cargo test --bin ohmyoled
+        run: cargo test --bin ohmyoled --no-default-features
+
+      - name: cargo clippy
+        run: cargo clippy --lib --bin ohmyoled --no-default-features --examples -- -D warnings
+
+      # Sanity-check the example configs still parse after any registry
+      # field additions. The cross-format equivalence catches typos in
+      # one format that the others would tolerate.
+      - name: example configs round-trip
+        run: cargo run --no-default-features --example config_formats

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,12 @@ jobs:
           restore-keys: |
             cargo-${{ runner.os }}-
 
+      # Matrix renderers + their tests load TTF/BDF fonts at runtime.
+      # The font files aren't tracked in git (per CLAUDE.md); the script
+      # fetches them from the `fonts-vN` release tarball.
+      - name: Fetch fonts
+        run: bash scripts/fetch-fonts.sh
+
       # --no-default-features skips the hardware backend (rpi-led-matrix-sys
       # refuses to build off-Pi); CI doesn't drive panels.
       - name: cargo build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,21 @@
 name: Release
 
-# Fires on semver-style version tags (v1.2.3) — not on the separate
-# fonts-vN tags used for the runtime fonts tarball.
+# Two trigger shapes:
+#  - Semver tag (v1.2.3): full release — cross-compiled binaries,
+#    starter config, GitHub Release page, versioned Docker images
+#    (`:v1.2.3`, `:latest`).
+#  - Push to main: rolling `:main` / `:latest` Docker images only;
+#    no GitHub Release (releases need unique tags) and no binary
+#    artifacts uploaded.
+#
+# Branch CI (tests, clippy) lives in ci.yml — fires on dev pushes
+# and PRs to main.
 on:
   push:
     tags:
       - 'v*.*.*'
+    branches:
+      - main
 
 permissions:
   contents: write
@@ -67,9 +77,11 @@ jobs:
   # Run a native build of the just-tagged commit and use the binary itself
   # to emit the starter config. Keeps the JSON in lockstep with the
   # `default_config()` Rust source — no risk of a hand-maintained sample
-  # drifting from the code.
+  # drifting from the code. Only needed for the GitHub Release upload, so
+  # skipped on plain `main` pushes.
   starter:
     name: Generate starter config
+    if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -92,6 +104,8 @@ jobs:
 
   release:
     name: Publish release
+    # GitHub Releases need a unique tag; only run on semver tag pushes.
+    if: github.ref_type == 'tag'
     needs: [build, starter]
     runs-on: ubuntu-latest
     steps:
@@ -162,13 +176,22 @@ jobs:
       - name: Stage binary
         run: mv ${{ matrix.artifact }} ohmyoled && chmod +x ohmyoled
 
+      # Tag/branch dispatch — semver tag becomes the image tag verbatim
+      # (`v3.6.1-aarch64-…`); pushes to main become `main-aarch64-…`.
+      # The manifest job aliases those into `:v3.6.1` + `:latest` (tag)
+      # or `:main` + `:latest` (branch).
       - name: Compute image tags
         id: tags
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
         run: |
           GHCR="ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')"
-          TAG="${{ github.ref_name }}-${{ matrix.target }}"
+          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+            VERSION="${{ github.ref_name }}"
+          else
+            VERSION="main"
+          fi
+          TAG="$VERSION-${{ matrix.target }}"
           TAGS="$GHCR:$TAG"
           if [ -n "$DOCKERHUB_USERNAME" ]; then
             TAGS="$TAGS"$'\n'"docker.io/${DOCKERHUB_USERNAME}/ohmyoled:$TAG"
@@ -178,6 +201,7 @@ jobs:
             echo "$TAGS"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - uses: docker/setup-qemu-action@v3
 
@@ -207,7 +231,7 @@ jobs:
           push: true
           provenance: false
           build-args: |
-            OHMYOLED_VERSION=${{ github.ref_name }}
+            OHMYOLED_VERSION=${{ steps.tags.outputs.version }}
           tags: ${{ steps.tags.outputs.list }}
 
   # Glue the per-arch images into a multi-arch manifest, on each
@@ -242,19 +266,25 @@ jobs:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
         run: |
           GHCR="ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')"
-          TAG="${{ github.ref_name }}"
-          # GHCR
+          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+            VERSION="${{ github.ref_name }}"
+          else
+            VERSION="main"
+          fi
+          # GHCR — versioned alias (`:v3.6.1` or `:main`) plus `:latest`.
+          # The version alias is stable; `:latest` always points at the
+          # most recent push (whether tag or main).
           docker buildx imagetools create \
-            --tag "$GHCR:$TAG" \
+            --tag "$GHCR:$VERSION" \
             --tag "$GHCR:latest" \
-            "$GHCR:$TAG-aarch64-unknown-linux-gnu" \
-            "$GHCR:$TAG-armv7-unknown-linux-gnueabihf"
+            "$GHCR:$VERSION-aarch64-unknown-linux-gnu" \
+            "$GHCR:$VERSION-armv7-unknown-linux-gnueabihf"
           # Docker Hub (only if the secret is set)
           if [ -n "$DOCKERHUB_USERNAME" ]; then
             HUB="docker.io/${DOCKERHUB_USERNAME}/ohmyoled"
             docker buildx imagetools create \
-              --tag "$HUB:$TAG" \
+              --tag "$HUB:$VERSION" \
               --tag "$HUB:latest" \
-              "$HUB:$TAG-aarch64-unknown-linux-gnu" \
-              "$HUB:$TAG-armv7-unknown-linux-gnueabihf"
+              "$HUB:$VERSION-aarch64-unknown-linux-gnu" \
+              "$HUB:$VERSION-armv7-unknown-linux-gnueabihf"
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,9 +88,17 @@ pub trait Renderer: Send {
 }
 ```
 
-**`refresh_interval`** caps how often `poll()` is called per module —
-e.g. weather 600 s, stock 30 s, time 1 s. The scheduler caches the last
-good output and re-renders it between polls.
+**`refresh_interval`** is the per-module poll cadence — e.g. weather
+600 s, stock 30 s, time 1 s. A background `tokio::spawn`'d task owns
+the collector, calls `poll().await`, publishes the result via
+`tokio::sync::watch::channel::<Option<Arc<Output>>>`, then sleeps for
+the interval. The scheduler's render loop reads the latest value via
+`watch::Receiver::borrow()` — it never blocks on the network. Each
+section can override the cadence with `cache_ttl_secs: <int>` in
+config: `Some(n > 0)` ⇒ override the collector's default; `Some(0)`
+⇒ no background task, the renderer polls inline on every render
+(always fresh, panel briefly stalls during the round-trip); `None`
+(omitted) ⇒ use `refresh_interval()`.
 
 **`cycle_duration`** is the renderer's contract for how long one full
 render cycle takes (e.g. weather 65 s for both screens + scroll +
@@ -222,6 +230,10 @@ deserialize it via `one_or_many`, and emit modules in `build()`.
 pub struct SubwaySection {
     pub run: bool,
     pub station_id: String,
+    /// Optional override for the background poll cadence — see the
+    /// "polling model" notes above. Same shape on every section.
+    #[serde(default)]
+    pub cache_ttl_secs: Option<u64>,
 }
 
 // 3b. field on RegistryConfig
@@ -231,7 +243,9 @@ pub struct RegistryConfig {
     pub subway: Vec<SubwaySection>,
 }
 
-// 3c. builder helper
+// 3c. builder helper — `module_with_ttl` resolves cache_ttl_secs to a
+// Duration (or falls back to collector.refresh_interval()) and either
+// spawns a background poll task or stages an inline-poll renderer.
 async fn build_subway(s: &SubwaySection) -> Result<Box<dyn DynModule>, String> {
     let collector = SubwayCollector::from_mta(MtaConfig {
         station_id: s.station_id.clone(),
@@ -239,7 +253,7 @@ async fn build_subway(s: &SubwaySection) -> Result<Box<dyn DynModule>, String> {
     let renderer = SubwayMatrix::new_async()
         .await
         .map_err(|e| format!("subway fonts: {e}"))?;
-    Ok(Box::new(Module::new(collector, renderer)))
+    Ok(module_with_ttl(collector, renderer, s.cache_ttl_secs))
 }
 
 // 3d. loop in `build()`
@@ -373,6 +387,14 @@ scheduler.
 - **Variant-bearing sections use `#[serde(tag = "...", rename_all = "lowercase")]`**
   enums — see `SportSection` for the pattern. Don't nest separate
   top-level keys for variants of the same concept.
+- **Every section gets `cache_ttl_secs: Option<u64>`** with
+  `#[serde(default)]`. The `module_with_ttl(collector, renderer, s.cache_ttl_secs)`
+  helper in `registry.rs` turns it into a `Duration`, picking
+  `collector.refresh_interval()` when omitted and treating `Some(0)`
+  as "skip the background task, poll inline on every render." For
+  enum-shaped sections (`SportSection`), add the field to every
+  variant and expose a `cache_ttl_secs()` accessor that pulls it from
+  whichever variant matched — same pattern as the existing `run()`.
 
 ### Collectors
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "ohmyoled"
-version = "3.5.2"
+version = "3.6.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "ohmyoled"
-version = "3.6.0"
+version = "3.6.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "ohmyoled"
-version = "3.5.1"
+version = "3.5.2"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "ohmyoled"
-version = "3.6.0"
+version = "3.6.1"
 edition = "2021"
 default-run = "ohmyoled"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "ohmyoled"
-version = "3.5.2"
+version = "3.6.0"
 edition = "2021"
 default-run = "ohmyoled"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "ohmyoled"
-version = "3.5.1"
+version = "3.5.2"
 edition = "2021"
 default-run = "ohmyoled"
 

--- a/crates/ohmyoled-matrix/src/graphics/font.rs
+++ b/crates/ohmyoled-matrix/src/graphics/font.rs
@@ -107,6 +107,20 @@ impl Font {
         }
     }
 
+    /// Y-offset (relative to baseline) of the visual midpoint of the
+    /// rendered glyph bounding box for `text`. Used when an animation
+    /// needs to orbit a glyph's *visual* center, not the font's ascent-
+    /// box center — the ascent box can sit noticeably above the actual
+    /// ink for digits and uppercase letters.
+    ///
+    /// Negative values are above the baseline (typical).
+    pub fn text_v_center_from_baseline(&self, text: &str) -> i32 {
+        match self {
+            Self::Bdf(_) => -self.ascent() / 2,
+            Self::Ttf(t) => t.text_v_center_from_baseline(text),
+        }
+    }
+
     pub(crate) fn bdf(&self) -> Option<&BdfFont> {
         match self {
             Self::Bdf(b) => b.inner.as_ref(),

--- a/crates/ohmyoled-matrix/src/graphics/ttf.rs
+++ b/crates/ohmyoled-matrix/src/graphics/ttf.rs
@@ -70,4 +70,29 @@ impl TtfFont {
         }
         w.round() as i32
     }
+
+    /// Y-offset (relative to baseline) of the visual midpoint of the
+    /// rendered glyph bounding box for `text`. Negative = above the
+    /// baseline (typical for digits and uppercase letters).
+    ///
+    /// Returns `-ascent / 2` when no glyphs in `text` have an outline
+    /// (e.g., the string is empty or all whitespace).
+    pub fn text_v_center_from_baseline(&self, text: &str) -> i32 {
+        let scaled = self.font.as_scaled(self.scale);
+        let mut min_y: Option<f32> = None;
+        let mut max_y: Option<f32> = None;
+        for ch in text.chars() {
+            let glyph_id = scaled.glyph_id(ch);
+            let glyph = glyph_id.with_scale_and_position(self.scale, ab_glyph::point(0.0, 0.0));
+            if let Some(outlined) = scaled.outline_glyph(glyph) {
+                let b = outlined.px_bounds();
+                min_y = Some(min_y.map_or(b.min.y, |y| y.min(b.min.y)));
+                max_y = Some(max_y.map_or(b.max.y, |y| y.max(b.max.y)));
+            }
+        }
+        match (min_y, max_y) {
+            (Some(lo), Some(hi)) => ((lo + hi) / 2.0).round() as i32,
+            _ => -self.ascent() / 2,
+        }
+    }
 }

--- a/examples/configs/ohmyoled.json
+++ b/examples/configs/ohmyoled.json
@@ -25,7 +25,7 @@
     }
   ],
   "stock": [
-    { "run": true, "api": "finnhub",   "api_key": "YOUR_FINNHUB_KEY", "symbol": "AAPL", "chart": true },
+    { "run": true, "api": "finnhub",   "api_key": "YOUR_FINNHUB_KEY", "symbol": "AAPL", "chart": true, "cache_ttl_secs": 0 },
     { "run": true, "api": "finnhub",   "api_key": "YOUR_FINNHUB_KEY", "symbol": "MSFT" },
     { "run": true, "api": "coingecko", "api_key": null,               "symbol": "bitcoin" },
     { "run": true, "api": "coingecko", "api_key": null,               "symbol": "ethereum" }
@@ -33,7 +33,8 @@
   "iss": {
     "run": true,
     "lat": 40.7128,
-    "lon": -74.0060
+    "lon": -74.0060,
+    "cache_ttl_secs": 30
   },
   "quake": {
     "run": true,

--- a/examples/configs/ohmyoled.toml
+++ b/examples/configs/ohmyoled.toml
@@ -34,6 +34,11 @@ symbol = "AAPL"
 # Finance (Finnhub's /candle is paid-only); coingecko configs source
 # it from coingecko's own market_chart endpoint.
 chart = true
+# cache_ttl_secs controls how often the background tokio task re-polls
+# the upstream API: omit = collector default (30 s for live equities),
+# any positive integer = poll every N seconds, 0 = inline-poll on every
+# render (always fresh; the panel briefly stalls during the round-trip).
+cache_ttl_secs = 0
 
 [[stock]]
 run = true
@@ -124,6 +129,7 @@ feed = "significant_day"
 run = true
 lat = 40.7128
 lon = -74.0060
+cache_ttl_secs = 30           # poll wheretheiss.at every 30 s
 
 # Team sports + golf + F1 all live under [[sport]]. Each entry is
 # discriminated by its `sport` field. Team sports require `team_logo`;

--- a/examples/configs/ohmyoled.yaml
+++ b/examples/configs/ohmyoled.yaml
@@ -1,5 +1,12 @@
 # ohmyoled config — YAML form. Same shape as ohmyoled.json.
 # Sections that accept multiple instances (weather/stock/sport) are lists.
+#
+# Every section also accepts an optional `cache_ttl_secs: <int>` that
+# controls how often a background tokio task re-polls the upstream API:
+#   - omit (default): use the collector's built-in refresh_interval
+#   - any positive integer: poll every <int> seconds
+#   - 0: disable the background task; poll inline on every render
+#        (always fresh; the panel briefly stalls during the round-trip)
 
 matrix_options:
   chain_length: 1
@@ -34,10 +41,12 @@ stock:
     # chart from Yahoo Finance (Finnhub's /candle is paid-only);
     # coingecko configs source it from coingecko's market_chart.
     chart: true
+    cache_ttl_secs: 0         # opt out of caching: poll on every render
   - run: true
     api: finnhub
     api_key: YOUR_FINNHUB_KEY
     symbol: MSFT
+    # no cache_ttl_secs → use collector default (30 s for live equities)
   # Crypto entries reuse the stock renderer. `symbol` carries the
   # CoinGecko coin id (lowercase, e.g. "bitcoin", "ethereum"); the
   # display ticker is pulled from the API response. `api_key` is unused
@@ -123,6 +132,7 @@ iss:
   run: true
   lat: 40.7128
   lon: -74.0060
+  cache_ttl_secs: 30           # poll wheretheiss.at every 30 s
 
 # Team sports + golf + F1 all live under `sport`. Each entry is
 # discriminated by its `sport:` field. Team sports require `team_logo`;

--- a/src/createjson/aurora.rs
+++ b/src/createjson/aurora.rs
@@ -7,6 +7,8 @@ pub struct AuroraOptions {
     /// Kp value at which the "AURORA LIKELY" banner appears. 5 matches
     /// NOAA's G1 minor-storm threshold and the registry default.
     pub alert_threshold: u8,
+    #[serde(default)]
+    pub cache_ttl_secs: Option<u64>,
 }
 
 impl Default for AuroraOptions {
@@ -14,6 +16,7 @@ impl Default for AuroraOptions {
         Self {
             run: true,
             alert_threshold: 5,
+            cache_ttl_secs: None,
         }
     }
 }
@@ -29,11 +32,13 @@ pub fn configure() -> Result<AuroraOptions, String> {
             _ => ui::warn("Expected an integer in 0..=9"),
         }
     };
+    let cache_ttl_secs = ui::read_cache_ttl_secs();
 
     ui::success(&format!("Aurora — alert at Kp ≥ {alert_threshold}"));
     Ok(AuroraOptions {
         run: true,
         alert_threshold,
+        cache_ttl_secs,
     })
 }
 

--- a/src/createjson/f1.rs
+++ b/src/createjson/f1.rs
@@ -5,10 +5,12 @@ pub fn configure() -> Result<Value, String> {
     ui::section("Sport — Formula 1");
     ui::info("F1 uses the free jolpica/Ergast API — no configuration required.");
     ui::hint("Renderer rotates between the next race and the driver standings.");
+    let cache_ttl_secs = ui::read_cache_ttl_secs();
     ui::success("F1 added to the rotation");
     Ok(json!({
         "run": true,
         "sport": "f1",
+        "cache_ttl_secs": cache_ttl_secs,
     }))
 }
 

--- a/src/createjson/flights.rs
+++ b/src/createjson/flights.rs
@@ -8,6 +8,8 @@ pub struct FlightsOptions {
     pub lat: f64,
     pub lon: f64,
     pub radius_km: f32,
+    #[serde(default)]
+    pub cache_ttl_secs: Option<u64>,
 }
 
 impl Default for FlightsOptions {
@@ -17,6 +19,7 @@ impl Default for FlightsOptions {
             lat: 40.7128,
             lon: -74.0060,
             radius_km: 80.0,
+            cache_ttl_secs: None,
         }
     }
 }
@@ -35,12 +38,14 @@ pub fn configure() -> Result<FlightsOptions, String> {
         }
     };
 
+    let cache_ttl_secs = ui::read_cache_ttl_secs();
     ui::success(&format!("Flights — lat={lat:.4}, lon={lon:.4}, radius={radius_km}km"));
     Ok(FlightsOptions {
         run: true,
         lat,
         lon,
         radius_km,
+        cache_ttl_secs,
     })
 }
 

--- a/src/createjson/golf.rs
+++ b/src/createjson/golf.rs
@@ -17,11 +17,13 @@ pub fn configure() -> Result<Value, String> {
         "pga",
     );
 
+    let cache_ttl_secs = ui::read_cache_ttl_secs();
     ui::success(&format!("Golf — {} tour configured", tour.to_uppercase()));
     Ok(json!({
         "run": true,
         "sport": "golf",
         "tour": tour,
+        "cache_ttl_secs": cache_ttl_secs,
     }))
 }
 

--- a/src/createjson/hass.rs
+++ b/src/createjson/hass.rs
@@ -18,6 +18,8 @@ pub struct HassOptions {
     /// (sparkline). Falls back to `"state"` if history isn't available.
     #[serde(default = "default_display_mode")]
     pub display_mode: String,
+    #[serde(default)]
+    pub cache_ttl_secs: Option<u64>,
 }
 
 fn default_display_mode() -> String {
@@ -36,6 +38,7 @@ impl Default for HassOptions {
             nominal_color: (120, 220, 120),
             alarm_color: (255, 60, 60),
             display_mode: default_display_mode(),
+            cache_ttl_secs: None,
         }
     }
 }
@@ -71,6 +74,7 @@ pub fn configure() -> Result<HassOptions, String> {
     let nominal_color = read_rgb("Nominal-state RGB", (120, 220, 120));
     let alarm_color = read_rgb("Alarm-state RGB", (255, 60, 60));
     let display_mode = read_display_mode();
+    let cache_ttl_secs = ui::read_cache_ttl_secs();
 
     ui::success(&format!("HASS — {entity_id} @ {base_url} ({display_mode})"));
     Ok(HassOptions {
@@ -83,6 +87,7 @@ pub fn configure() -> Result<HassOptions, String> {
         nominal_color,
         alarm_color,
         display_mode,
+        cache_ttl_secs,
     })
 }
 

--- a/src/createjson/hass.rs
+++ b/src/createjson/hass.rs
@@ -14,6 +14,14 @@ pub struct HassOptions {
     pub alarm_state: Option<String>,
     pub nominal_color: (u8, u8, u8),
     pub alarm_color: (u8, u8, u8),
+    /// `"state"` (current), `"historical"` (recent list), or `"graph"`
+    /// (sparkline). Falls back to `"state"` if history isn't available.
+    #[serde(default = "default_display_mode")]
+    pub display_mode: String,
+}
+
+fn default_display_mode() -> String {
+    "state".to_owned()
 }
 
 impl Default for HassOptions {
@@ -27,6 +35,7 @@ impl Default for HassOptions {
             alarm_state: None,
             nominal_color: (120, 220, 120),
             alarm_color: (255, 60, 60),
+            display_mode: default_display_mode(),
         }
     }
 }
@@ -61,8 +70,9 @@ pub fn configure() -> Result<HassOptions, String> {
 
     let nominal_color = read_rgb("Nominal-state RGB", (120, 220, 120));
     let alarm_color = read_rgb("Alarm-state RGB", (255, 60, 60));
+    let display_mode = read_display_mode();
 
-    ui::success(&format!("HASS — {entity_id} @ {base_url}"));
+    ui::success(&format!("HASS — {entity_id} @ {base_url} ({display_mode})"));
     Ok(HassOptions {
         run: true,
         base_url: base_url.trim().to_string(),
@@ -72,7 +82,24 @@ pub fn configure() -> Result<HassOptions, String> {
         alarm_state,
         nominal_color,
         alarm_color,
+        display_mode,
     })
+}
+
+/// Re-prompt until the user enters one of the three known display
+/// modes. Lower-cased on parse so configs stay normalised.
+fn read_display_mode() -> String {
+    loop {
+        let raw = ui::read_line_default(
+            "Display mode: state / historical / graph",
+            "state",
+        );
+        let normalised = raw.trim().to_lowercase();
+        match normalised.as_str() {
+            "state" | "historical" | "graph" => return normalised,
+            _ => ui::warn("Expected one of: state, historical, graph"),
+        }
+    }
 }
 
 pub fn summary_line(opts: &HassOptions) -> String {

--- a/src/createjson/iss.rs
+++ b/src/createjson/iss.rs
@@ -6,6 +6,8 @@ pub struct IssOptions {
     pub run: bool,
     pub lat: f64,
     pub lon: f64,
+    #[serde(default)]
+    pub cache_ttl_secs: Option<u64>,
 }
 
 impl Default for IssOptions {
@@ -16,6 +18,7 @@ impl Default for IssOptions {
             run: true,
             lat: 40.7128,
             lon: -74.0060,
+            cache_ttl_secs: None,
         }
     }
 }
@@ -26,9 +29,10 @@ pub fn configure() -> Result<IssOptions, String> {
 
     let lat = read_coord("Latitude (degrees, -90..90)", 40.7128, -90.0, 90.0);
     let lon = read_coord("Longitude (degrees, -180..180)", -74.0060, -180.0, 180.0);
+    let cache_ttl_secs = ui::read_cache_ttl_secs();
 
     ui::success(&format!("ISS — lat={lat:.4}, lon={lon:.4}"));
-    Ok(IssOptions { run: true, lat, lon })
+    Ok(IssOptions { run: true, lat, lon, cache_ttl_secs })
 }
 
 pub fn summary_line(opts: &IssOptions) -> String {

--- a/src/createjson/launch.rs
+++ b/src/createjson/launch.rs
@@ -8,6 +8,8 @@ pub struct LaunchOptions {
     /// Launch Library `launch_service_provider.name`. Empty = every
     /// upcoming launch.
     pub agency_filter: Vec<String>,
+    #[serde(default)]
+    pub cache_ttl_secs: Option<u64>,
 }
 
 impl Default for LaunchOptions {
@@ -15,6 +17,7 @@ impl Default for LaunchOptions {
         Self {
             run: true,
             agency_filter: Vec::new(),
+            cache_ttl_secs: None,
         }
     }
 }
@@ -33,6 +36,7 @@ pub fn configure() -> Result<LaunchOptions, String> {
         .filter(|s| !s.is_empty())
         .collect();
 
+    let cache_ttl_secs = ui::read_cache_ttl_secs();
     if agency_filter.is_empty() {
         ui::success("Launch — all providers");
     } else {
@@ -41,6 +45,7 @@ pub fn configure() -> Result<LaunchOptions, String> {
     Ok(LaunchOptions {
         run: true,
         agency_filter,
+        cache_ttl_secs,
     })
 }
 

--- a/src/createjson/mod.rs
+++ b/src/createjson/mod.rs
@@ -163,9 +163,85 @@ pub fn default_config() -> Value {
     serde_json::from_str(json).expect("starter config must parse")
 }
 
+/// Section names recognised when merging an existing config back in.
+const KNOWN_SECTIONS: &[&str] = &[
+    "time", "weather", "stock", "sport", "iss", "quake", "aurora",
+    "flights", "launch", "hass", "pihole",
+];
+
+/// Pull existing entries out of a previously-written config so the
+/// builder can pre-populate them and let the user append / undo rather
+/// than starting blank. A section that's an array becomes one entry
+/// per array element; a single object becomes one entry. Unknown or
+/// malformed sections are skipped (the builder rewrites them faithfully
+/// because the JSON `Value` survives round-trip).
+fn load_existing_entries(existing: &Value) -> (Vec<Entry>, MatrixOptions) {
+    let mut entries = Vec::new();
+    let matrix_opts = existing
+        .get("matrix_options")
+        .and_then(|mo| serde_json::from_value::<MatrixOptions>(mo.clone()).ok())
+        .unwrap_or_default();
+
+    for &section in KNOWN_SECTIONS {
+        let Some(v) = existing.get(section) else { continue };
+        let items: Vec<Value> = match v {
+            Value::Array(arr) => arr.clone(),
+            Value::Object(_) => vec![v.clone()],
+            _ => continue,
+        };
+        for item in items {
+            let label = describe_existing_entry(section, &item);
+            entries.push(Entry { section, label, value: item });
+        }
+    }
+    (entries, matrix_opts)
+}
+
+/// One-line summary for a pre-loaded entry. Pulls the obvious
+/// identifier per section (symbol / city / entity / team) so the user
+/// can recognise what's already there without re-running each module's
+/// `configure()` to regenerate the summary.
+fn describe_existing_entry(section: &'static str, value: &Value) -> String {
+    let str_field = |key: &str| -> Option<String> {
+        value.get(key).and_then(|v| v.as_str()).map(|s| s.to_string())
+    };
+    let suffix = match section {
+        "weather" => str_field("api").map(|s| format!(" ({s})")),
+        "stock" => str_field("symbol").map(|s| format!(" ({s})")),
+        "sport" => {
+            let kind = str_field("sport").unwrap_or_else(|| "?".into());
+            let team = value
+                .get("team_logo")
+                .and_then(|t| t.get("name"))
+                .and_then(|n| n.as_str());
+            match team {
+                Some(name) => Some(format!(": {kind} ({name})")),
+                None => Some(format!(": {kind}")),
+            }
+        }
+        "hass" => str_field("entity_id").map(|s| format!(" ({s})")),
+        "iss" | "flights" => {
+            match (value.get("lat").and_then(|v| v.as_f64()), value.get("lon").and_then(|v| v.as_f64())) {
+                (Some(lat), Some(lon)) => Some(format!(" ({lat:.2}, {lon:.2})")),
+                _ => None,
+            }
+        }
+        _ => None,
+    };
+    format!(
+        "{section}{} — existing",
+        suffix.unwrap_or_default()
+    )
+}
+
 /// Build the on-disk config interactively (or with `dev_mode = true` for the
 /// canned dev config).
-pub fn create_json(dev_mode: bool) -> Value {
+///
+/// When `existing` is `Some`, pre-load its entries + matrix options so
+/// the user can append to / undo from the current config instead of
+/// starting blank. Passing `None` (overwrite mode) yields the legacy
+/// fresh-start behavior.
+pub fn create_json(dev_mode: bool, existing: Option<Value>) -> Value {
     if dev_mode {
         let dev_json = r#"{
             "matrix_options": {"chain_length":1,"parallel":1,"brightness":50,"oled_slowdown":3,"fail_on_error":false,"hardware_mapping":"adafruit-hat"},
@@ -185,8 +261,20 @@ pub fn create_json(dev_mode: bool) -> Value {
     ui::info("Pick the modules you want on the panel. Most options have sane defaults.");
     ui::hint("Selections are accumulated below — sport entries can mix team sports, golf, and F1.");
 
-    let mut entries: Vec<Entry> = Vec::new();
-    let mut matrix_opts = MatrixOptions::default();
+    let (mut entries, mut matrix_opts): (Vec<Entry>, MatrixOptions) = match existing {
+        Some(v) => {
+            let (entries, opts) = load_existing_entries(&v);
+            if !entries.is_empty() {
+                ui::success(&format!(
+                    "Loaded {} entr{} from existing config — append or `u` to remove",
+                    entries.len(),
+                    if entries.len() == 1 { "y" } else { "ies" }
+                ));
+            }
+            (entries, opts)
+        }
+        None => (Vec::new(), MatrixOptions::default()),
+    };
 
     loop {
         print_menu(&entries);
@@ -341,4 +429,83 @@ pub fn create_json(dev_mode: bool) -> Value {
     }
 
     Value::Object(config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_existing_expands_arrays_and_objects() {
+        // Mixed shape: stock is an array, weather is a single object,
+        // sport carries a team_logo with a name, hass is an array.
+        // Each item should land as its own Entry.
+        let existing = serde_json::json!({
+            "matrix_options": {
+                "chain_length": 2, "parallel": 1, "brightness": 70,
+                "oled_slowdown": 3, "fail_on_error": false,
+                "hardware_mapping": "adafruit-hat"
+            },
+            "time": {"run": true, "color": [255, 255, 255]},
+            "weather": {"run": true, "api": "nws"},
+            "stock": [
+                {"run": true, "api": "finnhub", "symbol": "AAPL"},
+                {"run": true, "api": "finnhub", "symbol": "MSFT"}
+            ],
+            "sport": [
+                {"run": true, "sport": "basketball", "team_logo": {"name": "Boston Celtics"}},
+                {"run": true, "sport": "f1"}
+            ],
+            "iss": {"run": true, "lat": 40.7128, "lon": -74.0060},
+            "hass": [{"run": true, "entity_id": "sensor.kitchen_temp"}]
+        });
+        let (entries, opts) = load_existing_entries(&existing);
+        let sections: Vec<&str> = entries.iter().map(|e| e.section).collect();
+        // 1 time + 1 weather + 2 stock + 2 sport + 1 iss + 1 hass = 8
+        assert_eq!(entries.len(), 8);
+        assert!(sections.contains(&"time"));
+        assert!(sections.contains(&"weather"));
+        assert_eq!(sections.iter().filter(|s| **s == "stock").count(), 2);
+        assert_eq!(sections.iter().filter(|s| **s == "sport").count(), 2);
+        assert!(sections.contains(&"hass"));
+        // Matrix options carried through.
+        assert_eq!(opts.chain_length, 2);
+        assert_eq!(opts.brightness, 70);
+    }
+
+    #[test]
+    fn describe_picks_up_identifying_fields() {
+        let stock = serde_json::json!({"symbol": "AAPL", "api": "finnhub"});
+        assert!(describe_existing_entry("stock", &stock).contains("AAPL"));
+
+        let weather = serde_json::json!({"api": "nws"});
+        assert!(describe_existing_entry("weather", &weather).contains("nws"));
+
+        let hass = serde_json::json!({"entity_id": "sensor.kitchen_temp"});
+        assert!(describe_existing_entry("hass", &hass).contains("sensor.kitchen_temp"));
+
+        let sport = serde_json::json!({
+            "sport": "basketball",
+            "team_logo": {"name": "Boston Celtics"}
+        });
+        let s = describe_existing_entry("sport", &sport);
+        assert!(s.contains("basketball"));
+        assert!(s.contains("Boston Celtics"));
+
+        let iss = serde_json::json!({"lat": 40.7128, "lon": -74.0060});
+        let s = describe_existing_entry("iss", &iss);
+        assert!(s.contains("40.71"));
+        assert!(s.contains("-74.01"));
+    }
+
+    #[test]
+    fn load_existing_skips_unknown_sections_cleanly() {
+        let existing = serde_json::json!({
+            "time": {"run": true, "color": [255, 255, 255]},
+            "made_up_section": {"foo": "bar"}
+        });
+        let (entries, _) = load_existing_entries(&existing);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].section, "time");
+    }
 }

--- a/src/createjson/mod.rs
+++ b/src/createjson/mod.rs
@@ -157,7 +157,7 @@ pub fn default_config() -> Value {
         "aurora": {"run":false,"alert_threshold":5},
         "flights": {"run":false,"lat":40.7128,"lon":-74.0060,"radius_km":80.0},
         "launch": {"run":false,"agency_filter":[]},
-        "hass": {"run":false,"base_url":"http://homeassistant.local:8123","token":"REPLACE_ME_HASS_LONG_LIVED_TOKEN","entity_id":"sensor.kitchen_temp","label":"null","alarm_state":"null","nominal_color":[120,220,120],"alarm_color":[255,60,60]},
+        "hass": {"run":false,"base_url":"http://homeassistant.local:8123","token":"REPLACE_ME_HASS_LONG_LIVED_TOKEN","entity_id":"sensor.kitchen_temp","label":"null","alarm_state":"null","nominal_color":[120,220,120],"alarm_color":[255,60,60],"display_mode":"state"},
         "pihole": {"run":false,"base_url":"http://pi.hole","token":"null"}
     }"#;
     serde_json::from_str(json).expect("starter config must parse")

--- a/src/createjson/mod.rs
+++ b/src/createjson/mod.rs
@@ -81,7 +81,11 @@ fn print_menu(entries: &[Entry]) {
     println!();
     println!("  {}", ui::bold(&ui::cyan("Actions")));
     println!("    {} Matrix panel options", ui::bold("[m]"));
-    println!("    {} Undo last entry", ui::bold("[u]"));
+    println!("    {} Undo last entry, or `u N` to remove entry #N", ui::bold("[u]"));
+    println!(
+        "    {} `e N` to edit entry #N in place (re-runs that module's prompts)",
+        ui::bold("[e]")
+    );
     println!("    {} Continue and write config", ui::bold("[c]"));
     println!("    {} Quit without saving", ui::bold("[q]"));
     println!();
@@ -125,6 +129,113 @@ fn configure_matrix(current: &mut MatrixOptions) {
     );
 
     ui::success("Matrix options updated");
+}
+
+/// Re-run the prompts for an existing entry, returning a fresh
+/// `Entry` to insert in its place. Dispatches on `entry.section`
+/// (plus the inner `sport` tag when the section is `sport`) so the
+/// caller doesn't need to remember which module number maps to which
+/// configure() function.
+///
+/// Returns `None` if the underlying configure() reported an error or
+/// the section is unrecognised. The caller is responsible for
+/// restoring the original entry in that case — `e N` should never
+/// silently delete user data.
+fn re_configure_entry(entry: &Entry) -> Option<Entry> {
+    macro_rules! run_typed {
+        ($section:expr, $module:ident, $expect:expr) => {
+            match $module::configure() {
+                Ok(opts) => Some(Entry {
+                    section: $section,
+                    label: $module::summary_line(&opts),
+                    value: serde_json::to_value(opts).expect($expect),
+                }),
+                Err(e) => {
+                    ui::error(&format!("{}: {e}", $section));
+                    None
+                }
+            }
+        };
+    }
+    macro_rules! run_value {
+        ($section:expr, $module:ident) => {
+            match $module::configure() {
+                Ok(value) => Some(Entry {
+                    section: $section,
+                    label: $module::summary_line(&value),
+                    value,
+                }),
+                Err(e) => {
+                    ui::error(&format!("{}: {e}", $section));
+                    None
+                }
+            }
+        };
+    }
+    match entry.section {
+        "time" => {
+            let opts = time::configure();
+            Some(Entry {
+                section: "time",
+                label: time::summary_line(&opts),
+                value: serde_json::to_value(opts).expect("TimeOptions serializes"),
+            })
+        }
+        "weather" => run_typed!("weather", weather, "WeatherOptions serializes"),
+        "stock" => run_typed!("stock", stock, "StockOptions serializes"),
+        "sport" => {
+            // The "sport" section is the umbrella for three different
+            // configure() flows; pick the one matching the original's
+            // tag so editing a golf entry doesn't drop the user into
+            // a basketball prompt.
+            let kind = entry
+                .value
+                .get("sport")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            match kind {
+                "basketball" | "baseball" | "football" | "hockey" => {
+                    run_value!("sport", sport)
+                }
+                "golf" => run_value!("sport", golf),
+                "f1" => run_value!("sport", f1),
+                other => {
+                    ui::error(&format!("unknown sport variant `{other}` — can't edit"));
+                    None
+                }
+            }
+        }
+        "iss" => run_typed!("iss", iss, "IssOptions serializes"),
+        "quake" => run_typed!("quake", quake, "QuakeOptions serializes"),
+        "aurora" => run_typed!("aurora", aurora, "AuroraOptions serializes"),
+        "flights" => run_typed!("flights", flights, "FlightsOptions serializes"),
+        "launch" => run_typed!("launch", launch, "LaunchOptions serializes"),
+        "hass" => run_typed!("hass", hass, "HassOptions serializes"),
+        "pihole" => run_typed!("pihole", pihole, "PiholeOptions serializes"),
+        other => {
+            ui::error(&format!("unknown section `{other}` — can't edit"));
+            None
+        }
+    }
+}
+
+/// Parse a 1-based entry index from a user-supplied string. Returns
+/// the 0-based vec position on success, a user-facing error message
+/// otherwise. Used by the `u N` / `e N` action arms.
+fn parse_entry_index(s: &str, len: usize) -> Result<usize, String> {
+    let n: usize = s
+        .parse()
+        .map_err(|_| format!("`{s}` is not a positive integer"))?;
+    if n == 0 || n > len {
+        if len == 0 {
+            return Err("Nothing to remove — entry list is empty".into());
+        }
+        return Err(format!(
+            "No entry #{n} — valid range is 1..={}",
+            len
+        ));
+    }
+    Ok(n - 1)
 }
 
 /// Collapse repeated section entries into either a single object (count == 1)
@@ -282,7 +393,13 @@ pub fn create_json(dev_mode: bool, existing: Option<Value>) -> Value {
             Some(s) => s,
             None => continue,
         };
-        match raw.trim().to_lowercase().as_str() {
+        // Split into head + optional index arg — supports `u`, `u 3`, `e 2`.
+        let lowered = raw.trim().to_lowercase();
+        let (head, arg) = match lowered.split_once(char::is_whitespace) {
+            Some((h, rest)) => (h, rest.trim()),
+            None => (lowered.as_str(), ""),
+        };
+        match head {
             "1" => {
                 let opts = time::configure();
                 let label = time::summary_line(&opts);
@@ -383,10 +500,56 @@ pub fn create_json(dev_mode: bool, existing: Option<Value>) -> Value {
                 Err(e) => ui::error(&format!("pihole config failed: {e}")),
             },
             "m" => configure_matrix(&mut matrix_opts),
-            "u" => match entries.pop() {
-                Some(e) => ui::success(&format!("Removed: {}", e.label)),
-                None => ui::warn("Nothing to undo"),
-            },
+            "u" => {
+                if arg.is_empty() {
+                    match entries.pop() {
+                        Some(e) => ui::success(&format!("Removed: {}", e.label)),
+                        None => ui::warn("Nothing to undo"),
+                    }
+                } else {
+                    match parse_entry_index(arg, entries.len()) {
+                        Ok(idx) => {
+                            let removed = entries.remove(idx);
+                            ui::success(&format!("Removed #{}: {}", idx + 1, removed.label));
+                        }
+                        Err(e) => ui::warn(&e),
+                    }
+                }
+            }
+            "e" => {
+                if arg.is_empty() {
+                    ui::warn("Usage: `e N` — pick entry # from the summary above to edit");
+                } else {
+                    match parse_entry_index(arg, entries.len()) {
+                        Ok(idx) => {
+                            // Pull the entry out, hand it to the matching
+                            // module's `configure()` for a fresh prompt run,
+                            // then insert the new value at the original
+                            // index. On error or unrecognised section the
+                            // original entry is restored — `e N` never
+                            // silently destroys data.
+                            let original = entries.remove(idx);
+                            ui::info(&format!("Editing #{}: {}", idx + 1, original.label));
+                            match re_configure_entry(&original) {
+                                Some(new) => {
+                                    let new_label = new.label.clone();
+                                    entries.insert(idx, new);
+                                    ui::success(&format!(
+                                        "Replaced #{}: {new_label}", idx + 1
+                                    ));
+                                }
+                                None => {
+                                    ui::warn(
+                                        "Edit cancelled or failed — restoring original entry"
+                                    );
+                                    entries.insert(idx, original);
+                                }
+                            }
+                        }
+                        Err(e) => ui::warn(&e),
+                    }
+                }
+            }
             "c" => {
                 if entries.is_empty() {
                     ui::warn("No modules selected — add at least one before continuing");
@@ -496,6 +659,20 @@ mod tests {
         let s = describe_existing_entry("iss", &iss);
         assert!(s.contains("40.71"));
         assert!(s.contains("-74.01"));
+    }
+
+    #[test]
+    fn parse_entry_index_accepts_valid_one_based() {
+        assert_eq!(parse_entry_index("1", 3).unwrap(), 0);
+        assert_eq!(parse_entry_index("3", 3).unwrap(), 2);
+    }
+
+    #[test]
+    fn parse_entry_index_rejects_out_of_range_and_zero() {
+        assert!(parse_entry_index("0", 3).is_err());
+        assert!(parse_entry_index("4", 3).is_err());
+        assert!(parse_entry_index("abc", 3).is_err());
+        assert!(parse_entry_index("1", 0).is_err());
     }
 
     #[test]

--- a/src/createjson/mod.rs
+++ b/src/createjson/mod.rs
@@ -277,17 +277,17 @@ fn fold_section(values: Vec<Value>) -> Option<Value> {
 pub fn default_config() -> Value {
     let json = r#"{
         "matrix_options": {"chain_length":1,"parallel":1,"brightness":50,"oled_slowdown":3,"fail_on_error":false,"hardware_mapping":"adafruit-hat"},
-        "time": {"run":true,"color":[255,255,255],"time_format":"null","timezone":"null"},
-        "weather": {"run":false,"api":"nws","current_location":true,"current_location_api_key":"REPLACE_ME_IPINFO_TOKEN","weather_format":"imperial","animation":"subtle"},
-        "stock": {"run":false,"api":"finnhub","api_key":"REPLACE_ME_FINNHUB_API_KEY","symbol":"AAPL","chart":false},
+        "time": {"run":true,"color":[255,255,255],"time_format":"null","timezone":"null","cache_ttl_secs":null},
+        "weather": {"run":false,"api":"nws","current_location":true,"current_location_api_key":"REPLACE_ME_IPINFO_TOKEN","weather_format":"imperial","animation":"subtle","cache_ttl_secs":null},
+        "stock": {"run":false,"api":"finnhub","api_key":"REPLACE_ME_FINNHUB_API_KEY","symbol":"AAPL","chart":false,"cache_ttl_secs":null},
         "sport": [],
-        "iss": {"run":false,"lat":40.7128,"lon":-74.0060},
-        "quake": {"run":false,"feed":"significant_day"},
-        "aurora": {"run":false,"alert_threshold":5},
-        "flights": {"run":false,"lat":40.7128,"lon":-74.0060,"radius_km":80.0},
-        "launch": {"run":false,"agency_filter":[]},
-        "hass": {"run":false,"base_url":"http://homeassistant.local:8123","token":"REPLACE_ME_HASS_LONG_LIVED_TOKEN","entity_id":"sensor.kitchen_temp","label":"null","alarm_state":"null","nominal_color":[120,220,120],"alarm_color":[255,60,60],"display_mode":"state"},
-        "pihole": {"run":false,"base_url":"http://pi.hole","token":"null"}
+        "iss": {"run":false,"lat":40.7128,"lon":-74.0060,"cache_ttl_secs":null},
+        "quake": {"run":false,"feed":"significant_day","cache_ttl_secs":null},
+        "aurora": {"run":false,"alert_threshold":5,"cache_ttl_secs":null},
+        "flights": {"run":false,"lat":40.7128,"lon":-74.0060,"radius_km":80.0,"cache_ttl_secs":null},
+        "launch": {"run":false,"agency_filter":[],"cache_ttl_secs":null},
+        "hass": {"run":false,"base_url":"http://homeassistant.local:8123","token":"REPLACE_ME_HASS_LONG_LIVED_TOKEN","entity_id":"sensor.kitchen_temp","label":"null","alarm_state":"null","nominal_color":[120,220,120],"alarm_color":[255,60,60],"display_mode":"state","cache_ttl_secs":null},
+        "pihole": {"run":false,"base_url":"http://pi.hole","token":"null","cache_ttl_secs":null}
     }"#;
     serde_json::from_str(json).expect("starter config must parse")
 }

--- a/src/createjson/mod.rs
+++ b/src/createjson/mod.rs
@@ -86,6 +86,10 @@ fn print_menu(entries: &[Entry]) {
         "    {} `e N` to edit entry #N in place (re-runs that module's prompts)",
         ui::bold("[e]")
     );
+    println!(
+        "    {} `s N` to show entry #N's full JSON (so you can copy api_keys etc.)",
+        ui::bold("[s]")
+    );
     println!("    {} Continue and write config", ui::bold("[c]"));
     println!("    {} Quit without saving", ui::bold("[q]"));
     println!();
@@ -129,6 +133,20 @@ fn configure_matrix(current: &mut MatrixOptions) {
     );
 
     ui::success("Matrix options updated");
+}
+
+/// Pretty-print one entry's JSON so the user can read off api_keys /
+/// tokens / urls without having to look them up elsewhere. Falls back
+/// to compact form if pretty-printing somehow fails (shouldn't, but
+/// belt-and-braces — we never want this helper to swallow content).
+fn print_entry_json(entry: &Entry) {
+    let pretty = serde_json::to_string_pretty(&entry.value)
+        .unwrap_or_else(|_| entry.value.to_string());
+    println!();
+    for line in pretty.lines() {
+        println!("    {line}");
+    }
+    println!();
 }
 
 /// Re-run the prompts for an existing entry, returning a fresh
@@ -530,6 +548,12 @@ pub fn create_json(dev_mode: bool, existing: Option<Value>) -> Value {
                             // silently destroys data.
                             let original = entries.remove(idx);
                             ui::info(&format!("Editing #{}: {}", idx + 1, original.label));
+                            // Print the entry's current JSON so the user
+                            // can read off api_keys / tokens / urls
+                            // without leaving the prompt. Prompts still
+                            // default to the module's hard-coded values,
+                            // so this is the "look it up here" affordance.
+                            print_entry_json(&original);
                             match re_configure_entry(&original) {
                                 Some(new) => {
                                     let new_label = new.label.clone();
@@ -545,6 +569,21 @@ pub fn create_json(dev_mode: bool, existing: Option<Value>) -> Value {
                                     entries.insert(idx, original);
                                 }
                             }
+                        }
+                        Err(e) => ui::warn(&e),
+                    }
+                }
+            }
+            "s" => {
+                if arg.is_empty() {
+                    ui::warn("Usage: `s N` — pick entry # from the summary above to show");
+                } else {
+                    match parse_entry_index(arg, entries.len()) {
+                        Ok(idx) => {
+                            ui::info(&format!(
+                                "Entry #{}: {}", idx + 1, entries[idx].label
+                            ));
+                            print_entry_json(&entries[idx]);
                         }
                         Err(e) => ui::warn(&e),
                     }

--- a/src/createjson/pihole.rs
+++ b/src/createjson/pihole.rs
@@ -8,6 +8,8 @@ pub struct PiholeOptions {
     pub base_url: String,
     #[serde(default, deserialize_with = "null_string_as_none")]
     pub token: Option<String>,
+    #[serde(default)]
+    pub cache_ttl_secs: Option<u64>,
 }
 
 impl Default for PiholeOptions {
@@ -16,6 +18,7 @@ impl Default for PiholeOptions {
             run: true,
             base_url: "http://pi.hole".to_owned(),
             token: None,
+            cache_ttl_secs: None,
         }
     }
 }
@@ -34,12 +37,14 @@ pub fn configure() -> Result<PiholeOptions, String> {
     } else {
         Some(token_raw.trim().to_string())
     };
+    let cache_ttl_secs = ui::read_cache_ttl_secs();
 
     ui::success(&format!("Pi-hole — {}", base_url));
     Ok(PiholeOptions {
         run: true,
         base_url: base_url.trim().to_string(),
         token,
+        cache_ttl_secs,
     })
 }
 

--- a/src/createjson/quake.rs
+++ b/src/createjson/quake.rs
@@ -6,6 +6,8 @@ use serde::{Deserialize, Serialize};
 pub struct QuakeOptions {
     pub run: bool,
     pub feed: QuakeFeed,
+    #[serde(default)]
+    pub cache_ttl_secs: Option<u64>,
 }
 
 impl Default for QuakeOptions {
@@ -13,6 +15,7 @@ impl Default for QuakeOptions {
         Self {
             run: true,
             feed: QuakeFeed::default(),
+            cache_ttl_secs: None,
         }
     }
 }
@@ -38,8 +41,9 @@ pub fn configure() -> Result<QuakeOptions, String> {
         _ => QuakeFeed::SignificantDay,
     };
 
+    let cache_ttl_secs = ui::read_cache_ttl_secs();
     ui::success(&format!("Earthquake — feed={}", feed.slug()));
-    Ok(QuakeOptions { run: true, feed })
+    Ok(QuakeOptions { run: true, feed, cache_ttl_secs })
 }
 
 pub fn summary_line(opts: &QuakeOptions) -> String {

--- a/src/createjson/sport.rs
+++ b/src/createjson/sport.rs
@@ -17,6 +17,7 @@ fn default_entry() -> Value {
             sportsdbid: 135269,
             sportsipyid: None,
         },
+        "cache_ttl_secs": serde_json::Value::Null,
     })
 }
 
@@ -58,10 +59,12 @@ pub fn configure() -> Result<Value, String> {
     }
     let sport_kind = pick_sport();
     let logo = pick_team(&sport_kind);
+    let cache_ttl_secs = ui::read_cache_ttl_secs();
     let entry = json!({
         "run": true,
         "sport": sport_kind.get_sport_str(),
         "team_logo": logo,
+        "cache_ttl_secs": cache_ttl_secs,
     });
     ui::success(&format!(
         "Sport — {} ({}) added",

--- a/src/createjson/stock.rs
+++ b/src/createjson/stock.rs
@@ -15,6 +15,8 @@ pub struct StockOptions {
     /// keep parsing unchanged.
     #[serde(default)]
     pub chart: bool,
+    #[serde(default)]
+    pub cache_ttl_secs: Option<u64>,
 }
 
 impl Default for StockOptions {
@@ -25,6 +27,7 @@ impl Default for StockOptions {
             api_key: None,
             symbol: "AAPL".to_owned(),
             chart: false,
+            cache_ttl_secs: None,
         }
     }
 }
@@ -65,6 +68,7 @@ pub fn configure() -> Result<StockOptions, String> {
         "Also enable the 1D/1M/1Y historical chart tile?",
         false,
     );
+    let cache_ttl_secs = ui::read_cache_ttl_secs();
 
     let chart_tag = if chart { " + chart" } else { "" };
     ui::success(&format!("Stock — {symbol} via {}{chart_tag}", api.get_api()));
@@ -74,6 +78,7 @@ pub fn configure() -> Result<StockOptions, String> {
         api_key,
         symbol,
         chart,
+        cache_ttl_secs,
     })
 }
 

--- a/src/createjson/time.rs
+++ b/src/createjson/time.rs
@@ -10,6 +10,8 @@ pub struct TimeOptions {
     pub time_format: Option<String>,
     #[serde(default, deserialize_with = "null_string_as_none")]
     pub timezone: Option<String>,
+    #[serde(default)]
+    pub cache_ttl_secs: Option<u64>,
 }
 
 impl Default for TimeOptions {
@@ -19,6 +21,7 @@ impl Default for TimeOptions {
             color: (255, 255, 255),
             time_format: None,
             timezone: None,
+            cache_ttl_secs: None,
         }
     }
 }
@@ -73,6 +76,7 @@ pub fn configure() -> TimeOptions {
         "",
     );
     let timezone = if tz_raw.trim().is_empty() { None } else { Some(tz_raw) };
+    let cache_ttl_secs = ui::read_cache_ttl_secs();
 
     ui::success("Time configured");
     TimeOptions {
@@ -80,6 +84,7 @@ pub fn configure() -> TimeOptions {
         color,
         time_format,
         timezone,
+        cache_ttl_secs,
     }
 }
 

--- a/src/createjson/ui.rs
+++ b/src/createjson/ui.rs
@@ -113,6 +113,34 @@ pub fn choose(label: &str, choices: &[(&str, &str)], default: &str) -> String {
     }
 }
 
+/// Prompt for an optional `cache_ttl_secs`. Shared across every
+/// module's `configure()` so the override is available everywhere
+/// without each module rewriting the prompt.
+///
+/// - Blank input ⇒ `None`: use the collector's built-in
+///   `refresh_interval()` (the per-API default).
+/// - `0` ⇒ `Some(0)`: disable background polling — the renderer will
+///   call `collector.poll()` inline on every render. Always fresh,
+///   panel briefly stalls during the round-trip.
+/// - `N > 0` ⇒ `Some(N)`: background task polls every N seconds.
+pub fn read_cache_ttl_secs() -> Option<u64> {
+    hint("Override the background poll cadence? Leave blank for the API's default.");
+    loop {
+        let raw = read_line_default(
+            "cache_ttl_secs (blank | 0 = always fresh | N = every N seconds)",
+            "",
+        );
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+        match trimmed.parse::<u64>() {
+            Ok(n) => return Some(n),
+            Err(_) => warn(&format!("`{trimmed}` isn't a non-negative integer")),
+        }
+    }
+}
+
 /// Render the running summary of selected entries above the menu.
 pub fn summary(entries: &[String]) {
     println!("  {}", bold(&magenta("Pending configuration")));

--- a/src/createjson/weather.rs
+++ b/src/createjson/weather.rs
@@ -32,6 +32,8 @@ pub struct WeatherOptions {
     pub weather_format: Option<WeatherFormat>,
     #[serde(default, deserialize_with = "null_string_as_none")]
     pub current_location_api_key: Option<String>,
+    #[serde(default)]
+    pub cache_ttl_secs: Option<u64>,
 }
 
 impl Default for WeatherOptions {
@@ -44,6 +46,7 @@ impl Default for WeatherOptions {
             city: None,
             weather_format: Some(WeatherFormat::Imperial),
             current_location_api_key: None,
+            cache_ttl_secs: None,
         }
     }
 }
@@ -122,6 +125,7 @@ pub fn configure() -> Result<WeatherOptions, String> {
 
     let (current_location, city, ipinfo_token) = configure_location();
     let weather_format = pick_format();
+    let cache_ttl_secs = ui::read_cache_ttl_secs();
 
     ui::success(&format!(
         "Weather — {} ({}, {})",
@@ -138,6 +142,7 @@ pub fn configure() -> Result<WeatherOptions, String> {
         city,
         weather_format,
         current_location_api_key: ipinfo_token,
+        cache_ttl_secs,
     })
 }
 

--- a/src/lib/api/hass/mod.rs
+++ b/src/lib/api/hass/mod.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 pub mod model;
 pub mod rest;
 
-pub use model::HassEntity;
+pub use model::{HassEntity, HassSample};
 
 use rest::{RestConfig, RestProvider};
 

--- a/src/lib/api/hass/model.rs
+++ b/src/lib/api/hass/model.rs
@@ -8,6 +8,16 @@
 
 use chrono::{DateTime, Utc};
 
+/// One historical sample for a numeric HASS entity. Used by the
+/// renderer's `Graph` and `Historical` display modes. Sample order
+/// in `HassEntity::history` is chronological — oldest first, newest
+/// last (matching the order `/api/history/period/...` returns).
+#[derive(Debug, Clone, Copy)]
+pub struct HassSample {
+    pub at: DateTime<Utc>,
+    pub value: f64,
+}
+
 #[derive(Debug, Clone)]
 pub struct HassEntity {
     /// Raw state string as HASS reports it. `"72.4"`, `"on"`,
@@ -22,6 +32,12 @@ pub struct HassEntity {
     /// When HASS most recently observed a state change. Used to render
     /// "updated 12s ago" on the footer.
     pub last_changed: DateTime<Utc>,
+    /// Optional historical samples for numeric sensors. Powers the
+    /// `Graph` and `Historical` renderer modes. Empty for binary
+    /// entities or when the collector hasn't fetched history yet —
+    /// the renderer falls back to single-value `State` display in
+    /// that case.
+    pub history: Vec<HassSample>,
 }
 
 impl HassEntity {
@@ -51,6 +67,7 @@ mod tests {
             unit: Some("°F".into()),
             label: "Kitchen".into(),
             last_changed: t,
+            history: vec![],
         }
     }
 

--- a/src/lib/api/hass/rest.rs
+++ b/src/lib/api/hass/rest.rs
@@ -96,6 +96,11 @@ fn entity_from_raw(raw: RawState, label_override: Option<&str>, entity_id: &str)
         unit,
         label,
         last_changed,
+        // The /api/states endpoint only returns the current snapshot;
+        // populating `history` requires a separate /api/history call
+        // that's not yet wired up. The renderer falls back to State
+        // mode when history is empty.
+        history: vec![],
     }
 }
 

--- a/src/lib/matrix/aurora.rs
+++ b/src/lib/matrix/aurora.rs
@@ -57,6 +57,7 @@ const STORM: Color = Color { r: 200, g: 60, b: 255 };
 const SEVERE: Color = Color { r: 255, g: 30, b: 30 };
 const LABEL: Color = Color { r: 200, g: 200, b: 200 };
 const ALERT_BANNER: Color = Color { r: 0, g: 220, b: 255 };
+const CALM_BANNER: Color = Color { r: 140, g: 140, b: 160 };
 const BAR_OFF: Color = Color { r: 40, g: 40, b: 40 };
 
 /// Frame interval for the pulse animation — ~12 fps. Fine-grained enough
@@ -168,16 +169,21 @@ impl AuroraMatrix {
         // increasing phase offset so the shimmer reads as a wave.
         draw_kp_bar(&mut img, data.kp, 22, tick);
 
-        // Alert banner — same pulse driver as the digit, slightly subdued so
-        // the digit stays the dominant element.
-        if data.alert {
-            let banner = "AURORA LIKELY";
-            let banner_w = self.label_font.text_width(banner);
-            let banner_x = ((PANEL_W as i32 - banner_w) / 2).max(0);
-            let banner_y = (PANEL_H as i32) - 1;
-            let banner_color = scale_color(ALERT_BANNER, pulse_factor(data.kp, tick, 0.5));
-            draw_text(&mut img, &self.label_font, banner_x, banner_y, banner_color, banner);
-        }
+        // Bottom-row banner. Alert state pulses with the digit; calm state
+        // shows a static "CALM SKIES" label in dim grey so the tile reads
+        // as complete instead of half-empty next to the alert variant.
+        let (banner, banner_color) = if data.alert {
+            (
+                "AURORA LIKELY",
+                scale_color(ALERT_BANNER, pulse_factor(data.kp, tick, 0.5)),
+            )
+        } else {
+            ("CALM SKIES", CALM_BANNER)
+        };
+        let banner_w = self.label_font.text_width(banner);
+        let banner_x = ((PANEL_W as i32 - banner_w) / 2).max(0);
+        let banner_y = (PANEL_H as i32) - 1;
+        draw_text(&mut img, &self.label_font, banner_x, banner_y, banner_color, banner);
 
         img
     }
@@ -464,6 +470,28 @@ mod tests {
         assert_eq!(img.height(), 32);
         let lit = img.pixels().filter(|p| p.0 != [0, 0, 0]).count();
         assert!(lit > 80, "expected substantial lit pixels, got {lit}");
+    }
+
+    #[test]
+    fn low_kp_renders_calm_banner() {
+        // Regression: the low-Kp (alert: false) tile used to leave the
+        // bottom row entirely dark, making it read as half-drawn next
+        // to the alert variant. It should now show "CALM SKIES" in
+        // dim grey across the bottom rows.
+        let m = AuroraMatrix::with_fonts(repo_fonts()).expect("fonts");
+        let img = m.frame(&sample(2, false));
+        let mut lit_in_bottom = 0u32;
+        for y in (PANEL_H - 6)..PANEL_H {
+            for x in 0..PANEL_W {
+                if img.get_pixel(x, y).0 != [0, 0, 0] {
+                    lit_in_bottom += 1;
+                }
+            }
+        }
+        assert!(
+            lit_in_bottom > 10,
+            "calm-state banner should light bottom rows; got {lit_in_bottom} pixels"
+        );
     }
 
     #[test]

--- a/src/lib/matrix/flights.rs
+++ b/src/lib/matrix/flights.rs
@@ -383,6 +383,10 @@ const MARQUEE_GAP_PX: i32 = 6;
 /// callsign it read on the first one; after that, freezing at the
 /// head keeps the panel calm for the remainder of the cycle.
 const MARQUEE_PASSES: i32 = 2;
+/// Frames per scroll step. 1 = 1 px/frame (~20 px/sec on the 20 fps
+/// panel); raising this slows the marquee proportionally so callsigns
+/// are easier to read.
+const SCROLL_FRAMES_PER_STEP: u32 = 2;
 
 /// Draw `text` at `(dest_x, row_top)` clipped to `max_w` pixels. If
 /// the rendered width fits, draws once; otherwise marquees left at
@@ -411,7 +415,10 @@ fn draw_scrolling_text(
     // what makes the row legible after the second pass — without it
     // the panel would never stop moving.
     let total_scroll = cycle * MARQUEE_PASSES;
-    let phase = scroll_phase as i32;
+    // Quantise the incoming frame counter so each scroll step lasts
+    // `SCROLL_FRAMES_PER_STEP` frames — the marquee moves at
+    // (1 / SCROLL_FRAMES_PER_STEP) px per frame.
+    let phase = (scroll_phase / SCROLL_FRAMES_PER_STEP) as i32;
     let offset = if phase >= total_scroll {
         0
     } else {

--- a/src/lib/matrix/hass.rs
+++ b/src/lib/matrix/hass.rs
@@ -41,13 +41,13 @@
 //! `HassCollector::from_rest` — bearer-auth GET against the local
 //! HASS REST API. 30 s refresh.
 
-use crate::api::hass::HassEntity;
+use crate::api::hass::{HassEntity, HassSample};
 use crate::matrix::error::RenderError;
 use crate::matrix::renderer::Renderer;
 use async_trait::async_trait;
 use chrono::Utc;
 use image::RgbImage;
-use ohmyoled_matrix::graphics::{draw_text, Font};
+use ohmyoled_matrix::graphics::{draw_line, draw_text, Font};
 use ohmyoled_matrix::{Color, RGBMatrix};
 use std::path::PathBuf;
 use std::time::Duration;
@@ -59,12 +59,23 @@ const LABEL: Color = Color { r: 200, g: 200, b: 200 };
 const NOMINAL_DEFAULT: Color = Color { r: 120, g: 220, b: 120 };
 const ALARM_DEFAULT: Color = Color { r: 255, g: 60, b: 60 };
 const FOOTER: Color = Color { r: 130, g: 130, b: 130 };
+const PAST_VALUE: Color = Color { r: 170, g: 170, b: 170 };
+const PAST_AGE: Color = Color { r: 120, g: 120, b: 120 };
+const GRAPH_LINE: Color = Color { r: 120, g: 220, b: 120 };
+/// Marker ring drawn at the newest sparkline point — the "you are
+/// here" indicator, and the implicit anchor for a future scrolling
+/// graph (new samples would push in from this side).
+const GRAPH_MARKER: Color = Color { r: 255, g: 255, b: 255 };
 
 // Same hardcoded y-coord pattern as launch — guarantees a clear gap
 // between the centered state row and the footer.
 const LABEL_Y: i32 = 6;
 const STATE_Y: i32 = 19;
 const FOOTER_Y: i32 = 31;
+/// Sparkline vertical range for Graph mode — sits below the top
+/// header (which ends around y=6) and fills to the panel bottom.
+const GRAPH_TOP: i32 = 10;
+const GRAPH_BOTTOM: i32 = PANEL_H as i32 - 1;
 
 /// Render loop tick — 1 fps is plenty for "Nms ago" to tick visibly
 /// without burning CPU.
@@ -84,6 +95,25 @@ impl Default for HassFonts {
     }
 }
 
+/// Which of the three layouts to render. Picked per-entity in config.
+/// `Graph` and `Historical` fall back to `State` when the entity is
+/// non-numeric or its `history` is empty, so a misconfigured tile is
+/// never blank.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum HassDisplayMode {
+    /// Big current value, footer "updated Ns ago" (legacy default).
+    #[default]
+    State,
+    /// Current value on top + a stacked list of recent past samples
+    /// with their relative ages. Good for sensors where the trend
+    /// reads at a glance but a graph is overkill.
+    Historical,
+    /// Current value on top + a sparkline of `history`. Best for
+    /// fast-changing numeric sensors.
+    Graph,
+}
+
 /// Color configuration carried alongside the entity for renderer use.
 /// Held separately from `HassEntity` because it doesn't come from the
 /// HASS API — it's a per-config knob.
@@ -94,6 +124,7 @@ pub struct HassDisplay {
     /// State string (case-insensitive) that flips the color from
     /// `nominal_color` to `alarm_color`. `None` disables the flip.
     pub alarm_state: Option<String>,
+    pub mode: HassDisplayMode,
 }
 
 impl Default for HassDisplay {
@@ -102,6 +133,7 @@ impl Default for HassDisplay {
             nominal_color: NOMINAL_DEFAULT,
             alarm_color: ALARM_DEFAULT,
             alarm_state: None,
+            mode: HassDisplayMode::State,
         }
     }
 }
@@ -134,6 +166,27 @@ impl HassMatrix {
     }
 
     pub fn frame(&self, data: &HassEntity) -> RgbImage {
+        // Graph/Historical require a numeric series; fall back to
+        // single-value State when the entity isn't numeric or has no
+        // history yet (e.g., REST collector hasn't fetched it).
+        let mode = match self.display.mode {
+            HassDisplayMode::State => HassDisplayMode::State,
+            HassDisplayMode::Graph | HassDisplayMode::Historical
+                if !data.is_numeric() || data.history.is_empty() =>
+            {
+                HassDisplayMode::State
+            }
+            other => other,
+        };
+        match mode {
+            HassDisplayMode::State => self.frame_state(data),
+            HassDisplayMode::Historical => self.frame_historical(data),
+            HassDisplayMode::Graph => self.frame_graph(data),
+        }
+    }
+
+    /// Single-value layout: label / big centered state / "updated Ns ago".
+    fn frame_state(&self, data: &HassEntity) -> RgbImage {
         let mut img = RgbImage::new(PANEL_W, PANEL_H);
         let body = &self.body_font;
 
@@ -144,9 +197,9 @@ impl HassMatrix {
         // State — center, color depends on alarm_state match.
         let state_text = format_state(data);
         let color = self.state_color(&data.state);
-        let state_w = body.text_width(&state_text);
+        let state_w = text_width_with_degree(body, &state_text);
         let state_x = ((PANEL_W as i32 - state_w) / 2).max(0);
-        draw_text(&mut img, body, state_x, STATE_Y, color, &state_text);
+        draw_text_with_degree(&mut img, body, state_x, STATE_Y, color, &state_text);
 
         // Footer — "updated Ns ago" / "since Nm ago" depending on age.
         let footer_text = footer_for_age(data.age_seconds(Utc::now()), data.is_numeric());
@@ -155,6 +208,61 @@ impl HassMatrix {
         draw_text(&mut img, body, footer_x, FOOTER_Y, FOOTER, &footer_text);
 
         img
+    }
+
+    /// Stacked-list layout: header (label + current) on top, then up
+    /// to three past samples each rendered as "value  age".
+    fn frame_historical(&self, data: &HassEntity) -> RgbImage {
+        let mut img = RgbImage::new(PANEL_W, PANEL_H);
+        let body = &self.body_font;
+        self.draw_top_header(&mut img, data);
+
+        // Past samples — most recent first, drop the newest (it's the
+        // header). Three rows starting under the header, 7 px pitch.
+        // Last row ends at y=29, leaving a 2 px bottom margin.
+        let now = Utc::now();
+        let mut past: Vec<&HassSample> = data.history.iter().rev().skip(1).collect();
+        past.truncate(3);
+        for (i, sample) in past.iter().enumerate() {
+            let y_top = 10 + i as i32 * 7;
+            let baseline = y_top + body.ascent();
+            let value_text = format_history_value(sample.value, data.unit.as_deref());
+            draw_text_with_degree(&mut img, body, 2, baseline, PAST_VALUE, &value_text);
+
+            let age_secs = (now - sample.at).num_seconds().max(0) as u32;
+            let age_text = compact_age(age_secs);
+            let age_w = body.text_width(&age_text);
+            let age_x = PANEL_W as i32 - age_w - 2;
+            draw_text(&mut img, body, age_x, baseline, PAST_AGE, &age_text);
+        }
+        img
+    }
+
+    /// Sparkline layout: header (label + current) on top, then the
+    /// full `history` plotted across the bottom rows.
+    fn frame_graph(&self, data: &HassEntity) -> RgbImage {
+        let mut img = RgbImage::new(PANEL_W, PANEL_H);
+        self.draw_top_header(&mut img, data);
+        draw_sparkline(&mut img, &data.history, GRAPH_TOP, GRAPH_BOTTOM);
+        img
+    }
+
+    /// Top-row header used by both Graph and Historical: label on the
+    /// left in dim grey, current value (state + unit) on the right in
+    /// the alarm/nominal color.
+    fn draw_top_header(&self, img: &mut RgbImage, data: &HassEntity) {
+        let body = &self.body_font;
+        let baseline = LABEL_Y;
+        let color = self.state_color(&data.state);
+        let value_text = format_state(data);
+        let value_w = text_width_with_degree(body, &value_text);
+        let value_x = (PANEL_W as i32 - value_w - 2).max(0);
+        // Label gets whatever pixels are left after the value claims
+        // its right-aligned slot. Truncates with `…` if needed.
+        let label_max_w = (value_x - 4).max(0);
+        let label = truncate_to_width(&data.label, label_max_w, body);
+        draw_text(img, body, 1, baseline, LABEL, &label);
+        draw_text_with_degree(img, body, value_x, baseline, color, &value_text);
     }
 
     fn state_color(&self, state: &str) -> Color {
@@ -231,6 +339,166 @@ fn footer_for_age(age_secs: u32, is_numeric: bool) -> String {
     }
 }
 
+/// Compact a numeric history sample to fit the historical-row's
+/// value cell. Drops cents past 999 to leave room for the age cell.
+fn format_history_value(value: f64, unit: Option<&str>) -> String {
+    let n = if value.abs() >= 999.0 {
+        format!("{value:.0}")
+    } else {
+        format!("{value:.1}")
+    };
+    match unit {
+        Some(u) if !u.is_empty() => format!("{n}{u}"),
+        _ => n,
+    }
+}
+
+/// Compact age for the historical-row's age cell. Sparser than the
+/// `footer_for_age` style so it doesn't crowd the value: `45s`, `2m`,
+/// `1h`, `3d`.
+fn compact_age(age_secs: u32) -> String {
+    if age_secs < 60 {
+        format!("{age_secs}s")
+    } else if age_secs < 3_600 {
+        format!("{}m", age_secs / 60)
+    } else if age_secs < 86_400 {
+        format!("{}h", age_secs / 3_600)
+    } else {
+        format!("{}d", age_secs / 86_400)
+    }
+}
+
+/// Draw a sparkline of `history` clipped to the rectangle
+/// `(GRAPH_LEFT_INSET..PANEL_W - GRAPH_RIGHT_INSET) × (y_top..=y_bot)`.
+/// Empty / single-sample series do nothing — the caller already
+/// guarantees a non-empty series via the mode dispatch fallback.
+fn draw_sparkline(img: &mut RgbImage, history: &[HassSample], y_top: i32, y_bot: i32) {
+    const X_LEFT: i32 = 1;
+    const X_RIGHT: i32 = PANEL_W as i32 - 2;
+    if history.len() < 2 {
+        return;
+    }
+    let mut lo = f64::INFINITY;
+    let mut hi = f64::NEG_INFINITY;
+    for s in history {
+        if s.value < lo {
+            lo = s.value;
+        }
+        if s.value > hi {
+            hi = s.value;
+        }
+    }
+    // Flat series → draw a horizontal line mid-graph rather than
+    // dividing by zero in the normalization step.
+    if (hi - lo).abs() < f64::EPSILON {
+        let pad = lo.abs().max(1.0) * 0.005;
+        lo -= pad;
+        hi += pad;
+    }
+    let n = history.len();
+    let width_px = (X_RIGHT - X_LEFT) as f64;
+    let height_px = (y_bot - y_top) as f64;
+    let to_xy = |i: usize, v: f64| -> (i32, i32) {
+        // Stretch the series across the available pixel range so a
+        // short series doesn't bunch up on the left.
+        let t = if n > 1 { i as f64 / (n - 1) as f64 } else { 0.0 };
+        let x = X_LEFT + (t * width_px).round() as i32;
+        let frac = ((v - lo) / (hi - lo)).clamp(0.0, 1.0);
+        // Invert: higher value = smaller y (closer to top of graph).
+        let y = y_bot - (frac * height_px).round() as i32;
+        (x, y)
+    };
+    for i in 1..n {
+        let (x0, y0) = to_xy(i - 1, history[i - 1].value);
+        let (x1, y1) = to_xy(i, history[i].value);
+        draw_line(img, x0, y0, x1, y1, GRAPH_LINE);
+    }
+    // Mark the newest sample with a 4-pixel ring (diamond) — reads as
+    // a small circle at panel scale and tells the user where the
+    // current value sits on the time series, i.e. where new samples
+    // will appear as the data scrolls forward.
+    let (mx, my) = to_xy(n - 1, history[n - 1].value);
+    draw_marker_ring(img, mx, my);
+}
+
+fn draw_marker_ring(img: &mut RgbImage, cx: i32, cy: i32) {
+    let pixel = image::Rgb([GRAPH_MARKER.r, GRAPH_MARKER.g, GRAPH_MARKER.b]);
+    let w = img.width() as i32;
+    let h = img.height() as i32;
+    for (dx, dy) in [(-1, 0), (1, 0), (0, -1), (0, 1)] {
+        let px = cx + dx;
+        let py = cy + dy;
+        if px >= 0 && px < w && py >= 0 && py < h {
+            img.put_pixel(px as u32, py as u32, pixel);
+        }
+    }
+}
+
+/// Width of the manually-drawn degree mark, plus a 1 px gap after it.
+const DEGREE_GLYPH_W: i32 = 3;
+
+/// Pixel-space width of `text` assuming each `°` is rendered as a
+/// `DEGREE_GLYPH_W`-wide manual mark rather than the font's own (chunky
+/// 4×3 hollow-rect) glyph. Use this to size / center any string the
+/// renderer will hand to `draw_text_with_degree`.
+fn text_width_with_degree(font: &Font, text: &str) -> i32 {
+    let degrees = text.chars().filter(|c| *c == '°').count() as i32;
+    if degrees == 0 {
+        return font.text_width(text);
+    }
+    let font_degree_w = font.text_width("°");
+    font.text_width(text) - (font_degree_w - DEGREE_GLYPH_W) * degrees
+}
+
+/// `draw_text` with one tweak: every `°` is replaced by a small 2×2
+/// pixel mark anchored at the top of the line. The pixel font's
+/// native degree glyph reads as a chunky filled rectangle at 8 pt
+/// — the 2×2 mark mirrors the weather renderer's `draw_degree` and
+/// reads cleanly as a degree symbol next to a temperature.
+fn draw_text_with_degree(
+    img: &mut RgbImage,
+    font: &Font,
+    x: i32,
+    baseline: i32,
+    color: Color,
+    text: &str,
+) -> i32 {
+    let mut pen_x = x;
+    let mut last_end = 0usize;
+    for (i, ch) in text.char_indices() {
+        if ch == '°' {
+            let before = &text[last_end..i];
+            if !before.is_empty() {
+                pen_x = draw_text(img, font, pen_x, baseline, color, before);
+            }
+            draw_degree_mark(img, pen_x, baseline - font.ascent(), color);
+            pen_x += DEGREE_GLYPH_W;
+            last_end = i + ch.len_utf8();
+        }
+    }
+    if last_end < text.len() {
+        pen_x = draw_text(img, font, pen_x, baseline, color, &text[last_end..]);
+    }
+    pen_x
+}
+
+/// 2×2 filled mark anchored at `(x, line_top)` — the same shape
+/// `weather.rs::draw_degree` uses.
+fn draw_degree_mark(img: &mut RgbImage, x: i32, line_top: i32, color: Color) {
+    let pixel = image::Rgb([color.r, color.g, color.b]);
+    let w = img.width() as i32;
+    let h = img.height() as i32;
+    for dy in 0..2 {
+        for dx in 0..2 {
+            let px = x + dx;
+            let py = line_top + dy;
+            if px >= 0 && px < w && py >= 0 && py < h {
+                img.put_pixel(px as u32, py as u32, pixel);
+            }
+        }
+    }
+}
+
 /// Truncate `s` to a prefix that fits `max_px` plus an ellipsis. If it
 /// already fits, return it unchanged.
 fn truncate_to_width(s: &str, max_px: i32, font: &Font) -> String {
@@ -270,6 +538,7 @@ mod tests {
             unit: Some("°F".into()),
             label: "KITCHEN".into(),
             last_changed: Utc::now() - ChDuration::seconds(12),
+            history: vec![],
         }
     }
 
@@ -279,6 +548,7 @@ mod tests {
             unit: None,
             label: "GARAGE".into(),
             last_changed: Utc::now() - ChDuration::minutes(14),
+            history: vec![],
         }
     }
 
@@ -301,6 +571,7 @@ mod tests {
             unit: Some("ignored-on-binary".into()),
             label: "x".into(),
             last_changed: Utc::now(),
+            history: vec![],
         };
         let text = format_state(&e);
         assert_eq!(text, "OPEN");
@@ -393,6 +664,179 @@ mod tests {
             .filter(|&x| x > 62 && img.get_pixel(x, LABEL_Y as u32).0 != [0, 0, 0])
             .count();
         assert_eq!(label_far_right_lit, 0, "truncated label must not reach the right edge");
+    }
+
+    fn numeric_with_history(samples: &[(i64, f64)]) -> HassEntity {
+        let now = Utc::now();
+        let history = samples
+            .iter()
+            .map(|(secs_ago, v)| HassSample {
+                at: now - ChDuration::seconds(*secs_ago),
+                value: *v,
+            })
+            .collect();
+        HassEntity {
+            state: "72.4".into(),
+            unit: Some("°F".into()),
+            label: "KITCHEN".into(),
+            last_changed: now - ChDuration::seconds(12),
+            history,
+        }
+    }
+
+    fn matrix_with_mode(mode: HassDisplayMode) -> HassMatrix {
+        HassMatrix::with_fonts(
+            repo_fonts(),
+            HassDisplay {
+                mode,
+                ..HassDisplay::default()
+            },
+        )
+        .expect("fonts")
+    }
+
+    #[test]
+    fn historical_renders_past_value_rows() {
+        // With a numeric series + Historical mode, the panel should
+        // light pixels in y=10..30 (past-sample rows below the header).
+        let m = matrix_with_mode(HassDisplayMode::Historical);
+        let e = numeric_with_history(&[
+            (240, 70.0),
+            (180, 70.5),
+            (120, 71.2),
+            (60, 71.8),
+            (0, 72.4),
+        ]);
+        let img = m.frame(&e);
+        let past_lit = (0..PANEL_W)
+            .flat_map(|x| (10..30u32).map(move |y| (x, y)))
+            .filter(|&(x, y)| img.get_pixel(x, y).0 != [0, 0, 0])
+            .count();
+        assert!(
+            past_lit > 60,
+            "historical mode should fill the past-sample rows; got {past_lit}"
+        );
+    }
+
+    #[test]
+    fn graph_renders_sparkline_in_graph_band() {
+        // Graph mode lights GRAPH_LINE pixels in y=10..32, with the
+        // ascending series climbing toward the top of the band.
+        let m = matrix_with_mode(HassDisplayMode::Graph);
+        let e = numeric_with_history(&(0..12).map(|i| (60 * (12 - i) as i64, 68.0 + i as f64 * 0.3)).collect::<Vec<_>>());
+        let img = m.frame(&e);
+        let needle = [GRAPH_LINE.r, GRAPH_LINE.g, GRAPH_LINE.b];
+        let line_pixels = img.pixels().filter(|p| p.0 == needle).count();
+        assert!(
+            line_pixels > 30,
+            "graph mode should draw a sparkline; got {line_pixels} line pixels"
+        );
+    }
+
+    #[test]
+    fn graph_draws_marker_ring_at_newest_sample() {
+        // The newest sample on the right edge of the sparkline gets a
+        // small ring marker in GRAPH_MARKER (white) so the user can
+        // see "you are here" — the implicit anchor for new samples
+        // scrolling in.
+        let m = matrix_with_mode(HassDisplayMode::Graph);
+        let e = numeric_with_history(
+            &(0..12)
+                .map(|i| (60 * (12 - i) as i64, 68.0 + i as f64 * 0.3))
+                .collect::<Vec<_>>(),
+        );
+        let img = m.frame(&e);
+        let marker = [GRAPH_MARKER.r, GRAPH_MARKER.g, GRAPH_MARKER.b];
+        let mut found_marker_right_of_centre = false;
+        // Marker pixels live somewhere in x > PANEL_W/2 (the newest
+        // sample is on the right), inside the graph band.
+        for x in (PANEL_W / 2)..PANEL_W {
+            for y in (GRAPH_TOP as u32 - 1)..PANEL_H {
+                if img.get_pixel(x, y).0 == marker {
+                    found_marker_right_of_centre = true;
+                    break;
+                }
+            }
+        }
+        assert!(
+            found_marker_right_of_centre,
+            "graph mode should paint a white marker ring at the newest sample"
+        );
+    }
+
+    #[test]
+    fn graph_falls_back_to_state_for_binary_entity() {
+        // A binary entity (state="open") configured for Graph mode
+        // can't produce a line — fall back to the State layout so the
+        // tile isn't blank. Identify "state-mode" by the bottom-row
+        // "since Ns ago" footer being present.
+        let m = matrix_with_mode(HassDisplayMode::Graph);
+        let img = m.frame(&binary_sample());
+        // Footer lives in the y=25..32 strip.
+        let footer_lit = (0..PANEL_W)
+            .flat_map(|x| (25..32u32).map(move |y| (x, y)))
+            .filter(|&(x, y)| img.get_pixel(x, y).0 != [0, 0, 0])
+            .count();
+        assert!(
+            footer_lit > 5,
+            "Graph mode on a binary entity should fall back to State (footer present)"
+        );
+    }
+
+    #[test]
+    fn graph_falls_back_to_state_when_history_empty() {
+        let m = matrix_with_mode(HassDisplayMode::Graph);
+        let img = m.frame(&numeric_sample()); // history is empty
+        // Same footer-present heuristic.
+        let footer_lit = (0..PANEL_W)
+            .flat_map(|x| (25..32u32).map(move |y| (x, y)))
+            .filter(|&(x, y)| img.get_pixel(x, y).0 != [0, 0, 0])
+            .count();
+        assert!(footer_lit > 5);
+    }
+
+    #[test]
+    fn format_history_value_with_and_without_unit() {
+        assert_eq!(format_history_value(72.4, Some("°F")), "72.4°F");
+        assert_eq!(format_history_value(72.4, None), "72.4");
+        assert_eq!(format_history_value(72.4, Some("")), "72.4");
+        assert_eq!(format_history_value(1234.5, Some("kWh")), "1234kWh");
+    }
+
+    #[test]
+    fn degree_renders_as_compact_2x2_mark() {
+        // Regression: the font's native `°` glyph at 8 pt is a chunky
+        // 4×3 hollow rectangle that reads as a small box, not a
+        // degree symbol. The renderer must intercept it and draw a
+        // 2×2 mark instead. Verify by counting state-mode lit pixels
+        // with and without the unit: the difference should equal the
+        // degree mark's pixel count + the "F" glyph, both small.
+        let m = HassMatrix::with_fonts(repo_fonts(), HassDisplay::default()).expect("fonts");
+        let mut with_unit = numeric_sample();
+        with_unit.unit = Some("°F".into());
+        let mut without_unit = numeric_sample();
+        without_unit.unit = None;
+
+        let lit = |e: &HassEntity| {
+            m.frame(e).pixels().filter(|p| p.0 != [0, 0, 0]).count()
+        };
+        let degree_added = lit(&with_unit) as i32 - lit(&without_unit) as i32;
+        // 2×2 degree mark = 4 px, "F" glyph ≈ 9-11 px in 04B_03B 8pt,
+        // total ≈ 13-15. The legacy native-glyph path would have added
+        // 8 (4×3 hollow ring) + ~10 (F) ≈ 18 — assert we're notably
+        // under that.
+        assert!(
+            (10..17).contains(&degree_added),
+            "expected ~13-15 added pixels for '°F'; got {degree_added}"
+        );
+    }
+
+    #[test]
+    fn compact_age_units() {
+        assert_eq!(compact_age(12), "12s");
+        assert_eq!(compact_age(120), "2m");
+        assert_eq!(compact_age(3_900), "1h");
+        assert_eq!(compact_age(2 * 86_400), "2d");
     }
 
     /// Same hardcoded-spacing test as launch — guarantee a visible

--- a/src/lib/matrix/quake.rs
+++ b/src/lib/matrix/quake.rs
@@ -169,8 +169,8 @@ impl QuakeMatrix {
 
     fn draw_quiet(&self, img: &mut RgbImage) {
         let font = &self.body_font;
-        let banner = "QUIET";
-        let sub = "no events 24h";
+        let banner = "NO QUAKES";
+        let sub = "in last 24h";
         let banner_w = font.text_width(banner);
         let sub_w = font.text_width(sub);
         let line_h = font.height().max(font.ascent() + 1);
@@ -378,6 +378,24 @@ mod tests {
         );
         let lit_q = img_q.pixels().filter(|p| p.0 != [0, 0, 0]).count();
         assert!(lit_q > 30, "quiet banner should still light pixels");
+    }
+
+    #[test]
+    fn quiet_lines_fit_panel_width() {
+        // The quiet sub-line used to be "no events 24h", which measured
+        // wide enough to brush the 64 px panel edge in 04B_03B 8pt.
+        // Guard the literals so future text edits can't silently reintroduce
+        // clipping.
+        let m = QuakeMatrix::with_fonts(repo_fonts()).expect("fonts");
+        let font = &m.body_font;
+        for literal in ["NO QUAKES", "in last 24h"] {
+            let w = font.text_width(literal);
+            assert!(
+                w <= PANEL_W as i32 - 2,
+                "`{literal}` measures {w}px; must be <= {} to clear the panel edge",
+                PANEL_W as i32 - 2
+            );
+        }
     }
 
     #[test]

--- a/src/lib/matrix/stock_chart.rs
+++ b/src/lib/matrix/stock_chart.rs
@@ -13,9 +13,15 @@
 //!  └─────────────────────────────────────────────────┘
 //! ```
 //!
-//! - **Header (top 8 px)**: ticker (white), current price (white),
-//!   percent change (green / red / grey by [`Direction`]), and the
-//!   active period badge (`1D` / `1M` / `1Y`) in the top-right.
+//! - **Header (top 8 px)**: ticker (white), current price (white)
+//!   followed by the baseline price (`vs $180.10`) on the left strip,
+//!   percent change (green / red / grey by [`Direction`]) followed by
+//!   the absolute dollar change (`+$2.24`) on the right strip, and the
+//!   active period badge (`1D` / `1M` / `1Y`) in the top-right. Both
+//!   strips marquee twice and settle to the head (`AAPL  $182.34` on
+//!   the left, `+1.24%` on the right), so the baseline + dollar diff
+//!   read like a rolling caption while the dominant numbers stay
+//!   visible at rest.
 //! - **Graph (bottom 24 px)**: line drawn between consecutive closes.
 //!   The series is bucketed across the 62-px-wide plotting area so a
 //!   ~78-sample intraday window and a ~52-sample yearly window both
@@ -70,6 +76,10 @@ const GRAPH_RIGHT: i32 = PANEL_W as i32 - 2;
 
 // Palette.
 const HEADER_LABEL: Color = Color { r: 255, g: 255, b: 255 };
+/// Dim grey for the "vs $X.XX" tail on the left strip — reads as a
+/// caption to the white symbol+price head, not as data competing
+/// with it.
+const BASELINE_LABEL: Color = Color { r: 160, g: 160, b: 160 };
 const PERIOD_BADGE: Color = Color { r: 200, g: 200, b: 200 };
 const UP: Color = Color { r: 30, g: 220, b: 90 };
 const DOWN: Color = Color { r: 240, g: 70, b: 70 };
@@ -188,51 +198,81 @@ impl StockChartMatrix {
             Direction::Flat => FLAT,
         };
 
-        // Percent change — right-anchored just left of the badge,
-        // also always visible. The two right-side cells together
-        // anchor the eye while the symbol/price strip scrolls on the
-        // left if it needs to.
-        let pct_txt = if series.is_empty() {
+        // Right strip — percent change as the head, dollar change
+        // scrolling through. Slot is sized to the head exactly so the
+        // marquee settles to a clean "+1.24%" between scrolls; the
+        // dollar diff (`+$2.24`) twice per period rolls through the
+        // same slot to surface the absolute move.
+        let pct_head = if series.is_empty() {
             String::new()
         } else {
             format!("{:+.2}%", series.percent_change())
         };
-        let pct_w = body.text_width(&pct_txt);
+        let pct_head_w = body.text_width(&pct_head);
         let right_gap = 2;
-        let pct_x = label_x - pct_w - right_gap;
-        if !pct_txt.is_empty() {
-            draw_text(img, body, pct_x, baseline, pct_color, &pct_txt);
+        let pct_x = label_x - pct_head_w - right_gap;
+
+        if !pct_head.is_empty() && pct_head_w > 0 {
+            let baseline_price = series.closes.first().copied().unwrap_or(0.0);
+            let dollar_diff = data.current - baseline_price;
+            let diff_txt = format_signed_dollars(dollar_diff);
+            // Two-space separator matches the symbol/price strip.
+            let tail = format!("  {diff_txt}");
+            draw_scrolling_header(
+                img,
+                body,
+                &[(&pct_head, pct_color), (&tail, pct_color)],
+                pct_x,
+                baseline,
+                pct_head_w,
+                HEADER_H,
+                scroll_phase,
+            );
         }
 
-        // Everything left of the percent is the "symbol + price"
-        // strip. Compose them with a 2-px space and let
-        // `draw_scrolling_header` decide whether the strip fits
-        // statically or needs to marquee.
+        // Left strip — "symbol  $current" (white) + "  vs $baseline"
+        // (dim grey caption). Settles to the head so the user sees
+        // current price at rest; the baseline scrolls in twice per
+        // period to answer "vs what?". Coloring the caption distinctly
+        // keeps the user from misreading it as current data.
         let price = data.current;
         let price_txt = if price >= 1000.0 {
             format!("${price:.0}")
         } else {
             format!("${price:.2}")
         };
-        let strip = if series.is_empty() {
-            data.symbol.clone()
-        } else {
-            format!("{}  {}", data.symbol, price_txt)
-        };
-        // The strip occupies x=0..(pct_x - gap). Reserve one extra
-        // gap pixel so the strip never visually kisses the percent.
         let strip_w = pct_x - right_gap;
         if strip_w > 0 {
-            draw_scrolling_header(
-                img,
-                body,
-                &strip,
-                0,
-                baseline,
-                strip_w,
-                HEADER_LABEL,
-                scroll_phase,
-            );
+            if series.is_empty() {
+                draw_scrolling_header(
+                    img,
+                    body,
+                    &[(data.symbol.as_str(), HEADER_LABEL)],
+                    0,
+                    baseline,
+                    strip_w,
+                    HEADER_H,
+                    scroll_phase,
+                );
+            } else {
+                let baseline_price = series.closes.first().copied().unwrap_or(0.0);
+                let baseline_txt = if baseline_price >= 1000.0 {
+                    format!("  vs ${baseline_price:.0}")
+                } else {
+                    format!("  vs ${baseline_price:.2}")
+                };
+                let head = format!("{}  {}", data.symbol, price_txt);
+                draw_scrolling_header(
+                    img,
+                    body,
+                    &[(&head, HEADER_LABEL), (&baseline_txt, BASELINE_LABEL)],
+                    0,
+                    baseline,
+                    strip_w,
+                    HEADER_H,
+                    scroll_phase,
+                );
+            }
         }
     }
 
@@ -379,16 +419,25 @@ fn bucket_to_width(closes: &[f64], width_px: usize) -> Vec<f64> {
 /// from reading as a joined string.
 const MARQUEE_GAP_PX: i32 = 6;
 /// How many full passes the strip scrolls before settling at the head
-/// for the rest of the period. Two passes lets the eye verify the
-/// content; settling stops the panel from moving forever.
-const MARQUEE_PASSES: i32 = 2;
+/// for the rest of the period. One pass at half-scroll-speed leaves
+/// each strip ~5 s of dwell within a 14 s period; bumping to two would
+/// keep the left strip scrolling the entire period.
+const MARQUEE_PASSES: i32 = 1;
+/// Frames per scroll step. 1 = 1 px/frame (~20 fps panel ⇒ 20 px/sec);
+/// higher values slow the scroll proportionally. 2 → half speed, easier
+/// to read on a 64-px panel without making the user chase pixels.
+const SCROLL_FRAMES_PER_STEP: u32 = 2;
 
-/// Draw `text` at `(dest_x, baseline)` with `color`, clipped to
-/// `max_w` pixels. When the rendered text fits the slot it draws
+/// Draw a sequence of colored `segments` at `(dest_x, baseline)`,
+/// clipped to `max_w` pixels wide and `row_h` pixels tall (one font
+/// row). When the combined rendered width fits the slot it draws
 /// once; otherwise it marquees left and settles after
 /// `MARQUEE_PASSES`. Renders into a temp `RgbImage` and blits the
-/// visible window so nothing bleeds into the percent / badge cells
-/// to the right.
+/// visible window so nothing bleeds into adjacent cells.
+///
+/// Segments let one marquee mix colors (e.g. white symbol+price
+/// followed by a dim grey `vs $baseline` caption) without breaking
+/// the wrap-continuity of a single scrolling string.
 ///
 /// Inlined per the codebase convention (CLAUDE.md: "scroll loops are
 /// inlined per renderer; don't extract a shared helper").
@@ -396,21 +445,27 @@ const MARQUEE_PASSES: i32 = 2;
 fn draw_scrolling_header(
     img: &mut RgbImage,
     font: &Font,
-    text: &str,
+    segments: &[(&str, Color)],
     dest_x: i32,
     baseline: i32,
     max_w: i32,
-    color: Color,
+    row_h: i32,
     scroll_phase: u32,
 ) {
-    let text_w = font.text_width(text);
+    let text_w: i32 = segments.iter().map(|(t, _)| font.text_width(t)).sum();
     if text_w <= max_w {
-        draw_text(img, font, dest_x, baseline, color, text);
+        let mut x = dest_x;
+        for (text, color) in segments {
+            x = draw_text(img, font, x, baseline, *color, text);
+        }
         return;
     }
     let cycle = text_w + MARQUEE_GAP_PX;
     let total_scroll = cycle * MARQUEE_PASSES;
-    let phase = scroll_phase as i32;
+    // Quantise the incoming frame counter so each scroll step lasts
+    // `SCROLL_FRAMES_PER_STEP` frames — the scroll moves at
+    // (1 / SCROLL_FRAMES_PER_STEP) px per frame.
+    let phase = (scroll_phase / SCROLL_FRAMES_PER_STEP) as i32;
     let offset = if phase >= total_scroll {
         0
     } else {
@@ -418,23 +473,27 @@ fn draw_scrolling_header(
     };
 
     // Render two consecutive copies so a window straddling the wrap
-    // reads continuously.
+    // reads continuously. Each copy walks the segments in order so
+    // colored runs land at the same temp-x in both passes.
     let temp_w = (cycle * 2) as u32;
-    let row_h = HEADER_H as u32;
-    let mut temp = RgbImage::new(temp_w, row_h);
+    let temp_h = row_h as u32;
+    let mut temp = RgbImage::new(temp_w, temp_h);
     let temp_baseline = font.ascent();
-    draw_text(&mut temp, font, 0, temp_baseline, color, text);
-    draw_text(&mut temp, font, cycle, temp_baseline, color, text);
+    for copy_start in [0, cycle] {
+        let mut sx = copy_start;
+        for (text, color) in segments {
+            sx = draw_text(&mut temp, font, sx, temp_baseline, *color, text);
+        }
+    }
 
-    // The header sits in rows 0..HEADER_H — convert the temp's
-    // baseline-relative y back to row-top relative for the blit.
+    // Convert the temp's baseline-relative y back to row-top relative for the blit.
     let row_top = baseline - font.ascent();
     for x in 0..max_w {
         let src_x = offset + x;
         if src_x < 0 || src_x as u32 >= temp_w {
             continue;
         }
-        for y in 0..row_h as i32 {
+        for y in 0..row_h {
             let src = temp.get_pixel(src_x as u32, y as u32);
             if src.0 == [0, 0, 0] {
                 continue;
@@ -445,6 +504,19 @@ fn draw_scrolling_header(
                 img.put_pixel(dx as u32, dy as u32, *src);
             }
         }
+    }
+}
+
+/// Format a signed dollar amount as `+$2.24` / `-$5.67` — sign first,
+/// then `$`, so the user sees direction immediately. Large diffs
+/// (≥ $1000) drop the cents to keep the slot readable.
+fn format_signed_dollars(diff: f64) -> String {
+    let sign = if diff >= 0.0 { '+' } else { '-' };
+    let abs = diff.abs();
+    if abs >= 1000.0 {
+        format!("{sign}${abs:.0}")
+    } else {
+        format!("{sign}${abs:.2}")
     }
 }
 
@@ -540,6 +612,73 @@ mod tests {
     }
 
     #[test]
+    fn dollar_diff_scrolls_through_percent_cell() {
+        // Regression: the percent slot marquees "+1.24%  +$2.24" so
+        // the dollar change scrolls into view. At rest (phase 0) the
+        // slot shows the percent head; mid-cycle the dollar diff
+        // rolls through — so the right-side header band must differ
+        // between phases.
+        let m = StockChartMatrix::with_fonts(repo_fonts()).expect("fonts");
+        let h = sample(ramp(180.0, 0.05, 78), ramp(170.0, 0.5, 22), ramp(140.0, 0.8, 52));
+        let head = m.draw_frame(&h, Period::Day, 0);
+        // Pick a phase deep enough into the scroll that the marquee
+        // has shifted off the head.
+        let mid = m.draw_frame(&h, Period::Day, 40);
+        let right_band = |img: &RgbImage| -> Vec<[u8; 3]> {
+            ((PANEL_W / 2)..PANEL_W)
+                .flat_map(|x| (0..HEADER_H as u32).map(move |y| (x, y)))
+                .map(|(x, y)| img.get_pixel(x, y).0)
+                .collect()
+        };
+        assert_ne!(
+            right_band(&head),
+            right_band(&mid),
+            "percent cell should differ between settled head and mid-scroll"
+        );
+    }
+
+    #[test]
+    fn vs_baseline_uses_dim_grey_in_left_strip() {
+        // The "vs $X.XX" tail on the left strip should render in
+        // BASELINE_LABEL (dim grey), distinct from the white symbol
+        // + current price head. Sweep scroll phases so the tail
+        // definitely passes through the visible slot at some frame.
+        let m = StockChartMatrix::with_fonts(repo_fonts()).expect("fonts");
+        let h = sample(ramp(180.0, 0.05, 78), ramp(170.0, 0.5, 22), ramp(140.0, 0.8, 52));
+        let needle = [BASELINE_LABEL.r, BASELINE_LABEL.g, BASELINE_LABEL.b];
+        let mut hits = 0u32;
+        for phase in 0..FRAMES_PER_PERIOD {
+            let img = m.draw_frame(&h, Period::Day, phase);
+            // Left strip lives roughly in x=0..(PANEL_W/2). The
+            // baseline tail must show grey pixels somewhere there
+            // across the sweep.
+            for x in 0..(PANEL_W / 2) {
+                for y in 0..HEADER_H as u32 {
+                    if img.get_pixel(x, y).0 == needle {
+                        hits += 1;
+                    }
+                }
+            }
+            if hits > 5 {
+                break;
+            }
+        }
+        assert!(
+            hits > 5,
+            "vs $baseline tail should render in BASELINE_LABEL grey somewhere in the left strip"
+        );
+    }
+
+    #[test]
+    fn format_signed_dollars_styles() {
+        assert_eq!(format_signed_dollars(2.24), "+$2.24");
+        assert_eq!(format_signed_dollars(-5.67), "-$5.67");
+        assert_eq!(format_signed_dollars(0.0), "+$0.00");
+        assert_eq!(format_signed_dollars(1234.5), "+$1234");
+        assert_eq!(format_signed_dollars(-9999.99), "-$10000");
+    }
+
+    #[test]
     fn empty_window_shows_no_data_badge() {
         // An empty period draws the NO_DATA badge instead of a line.
         let m = StockChartMatrix::with_fonts(repo_fonts()).expect("fonts");
@@ -619,7 +758,7 @@ mod tests {
     }
 
     #[test]
-    fn marquee_settles_after_two_passes() {
+    fn marquee_settles_after_passes_complete() {
         // Past total_scroll, the strip pixels stop changing — same
         // contract as the flights marquee.
         let m = StockChartMatrix::with_fonts(repo_fonts()).expect("fonts");

--- a/src/lib/matrix/weather.rs
+++ b/src/lib/matrix/weather.rs
@@ -503,7 +503,7 @@ impl WeatherMatrix {
             .unwrap_or("---");
         let wind_t = (wind / 30.0).min(1.0);
         self.draw_comfort_bar(
-            &mut img, 24, "Wind", &format!("{} {wind_dir}", wind.round() as i32),
+            &mut img, 24, "Wind", &format!("{} mph {wind_dir}", wind.round() as i32),
             wind_t, fill_t, Color::new(201, 1, 253),
         );
 
@@ -572,7 +572,11 @@ impl WeatherMatrix {
         let color = uv_color(uv);
         draw_text(&mut img, &self.mid_font, left, baseline, color, &label);
         let cx = left + num_w / 2;
-        let cy = NUM_TOP + self.mid_font.ascent() / 2;
+        // Orbit center tracks the *visual* midpoint of the digit's ink,
+        // not the font's ascent-box midpoint — BMmini's ascent box sits
+        // ~1 px above the actual rasterized digit, so the legacy
+        // `NUM_TOP + ascent / 2` rays appeared slightly off-axis.
+        let cy = baseline + self.mid_font.text_v_center_from_baseline(&label);
         let num_y0 = NUM_TOP;
         let num_y1 = NUM_TOP + self.mid_font.ascent();
         let num_x0 = left;
@@ -593,8 +597,12 @@ impl WeatherMatrix {
             }
         }
 
-        // y=22..23 — color band scale with marker.
-        const BAND_Y: i32 = 22;
+        // Color band scale with marker. The band sits 2 rows below the
+        // digit so the rotating-ray orbit's bottom half (at y=cy+r ~ 22..23
+        // for the BMmini 14pt digit) stays visible instead of being
+        // overpainted — without this, the rays read as a top-only halo
+        // instead of orbiting the digit.
+        const BAND_Y: i32 = 24;
         const BAND_L: i32 = 4;
         const BAND_R: i32 = PANEL_W as i32 - 4;
         let band_w = (BAND_R - BAND_L) as f32;
@@ -1210,6 +1218,75 @@ mod tests {
         let m = matrix_subtle();
         let img = m.frame_uv(&sample_weather(), 5);
         assert!(lit_pixel_count(&img) > 60);
+    }
+
+    #[test]
+    fn uv_rays_visible_below_digit() {
+        // Regression: the band+marker used to sit immediately below
+        // the digit (BAND_Y=22), overpainting the bottom half of the
+        // ray orbit (cy=15 + r=7..8 lands at y=22..23). The user saw
+        // rays only above the digit, reading as a halo not an orbit.
+        // BAND_Y=24 leaves room for the orbit's bottom rays at y=21..22.
+        let m = matrix_subtle();
+        let w = sample_weather();
+        // Sweep a full rotation to be sure SOME frame draws a bottom
+        // ray in the gap between digit ink and marker.
+        let mut bottom_lit = 0u32;
+        for frame in 0..80u32 {
+            let img = m.frame_uv(&w, frame);
+            // Below the digit's ascent box (y >= 21), above the marker
+            // row (y < 23). Exclude the digit's own column footprint
+            // so we count rays, not the digit's tail.
+            for y in 21..23u32 {
+                for x in 0..PANEL_W {
+                    let p = img.get_pixel(x, y).0;
+                    if p == [0, 0, 0] || p == [255, 255, 255] {
+                        continue;
+                    }
+                    bottom_lit += 1;
+                }
+            }
+        }
+        assert!(
+            bottom_lit > 20,
+            "expected visible ray pixels below the digit across a full rotation, got {bottom_lit}"
+        );
+    }
+
+    #[test]
+    fn uv_ray_orbit_is_centered_on_digit_ink() {
+        // Regression: the orbit used to anchor at `NUM_TOP + ascent/2`
+        // — BMmini's ascent box sits ~1 px above the actual rendered
+        // digit ink, so the rays appeared off-axis. Verify the helper
+        // that frame_uv now uses (`text_v_center_from_baseline`)
+        // tracks the digit's *rendered* vertical centroid within 1 px.
+        let m = matrix_subtle();
+
+        for label in ["0", "5", "9", "11"] {
+            // Render the digit in isolation at a known baseline and
+            // measure the vertical centroid of its non-black pixels.
+            let baseline = 20i32;
+            let mut img = RgbImage::new(PANEL_W, PANEL_H);
+            draw_text(&mut img, &m.mid_font, 24, baseline, Color::WHITE, label);
+
+            let (mut sum_y, mut count) = (0.0f64, 0u32);
+            for y in 0..PANEL_H as i32 {
+                for x in 0..PANEL_W as i32 {
+                    if img.get_pixel(x as u32, y as u32).0 != [0, 0, 0] {
+                        sum_y += y as f64;
+                        count += 1;
+                    }
+                }
+            }
+            assert!(count > 0, "digit `{label}` must render some pixels");
+            let ink_centroid = sum_y / count as f64;
+            let helper_cy =
+                baseline as f64 + m.mid_font.text_v_center_from_baseline(label) as f64;
+            assert!(
+                (helper_cy - ink_centroid).abs() <= 1.0,
+                "for `{label}`: helper returned cy={helper_cy:.2}, ink centroid {ink_centroid:.2}"
+            );
+        }
     }
 
     #[test]

--- a/src/lib/modules/mod.rs
+++ b/src/lib/modules/mod.rs
@@ -92,8 +92,27 @@ where
 }
 
 /// Background poll loop — owns the collector, writes each fresh value
-/// into `tx` as an `Arc`, sleeps `ttl` between polls. Exits cleanly if
-/// every receiver has been dropped (panel shutdown).
+/// into `tx` as an `Arc`, sleeps `ttl` between polls.
+///
+/// ## TTL invariant
+///
+/// The cache is "invalidated" implicitly: every `ttl` seconds the loop
+/// wakes, polls the collector, and (on success) overwrites the
+/// channel's stored value. Renderers reading the channel always see
+/// the most-recent successful poll. There's no explicit cache-entry
+/// timestamp — the loop's own cadence enforces the freshness bound.
+///
+/// On a failed poll the previous value stays in the channel (better
+/// to render stale data than blank tiles); the next tick still fires
+/// at `ttl` later, so a transient API outage doesn't break the
+/// freshness budget once it recovers.
+///
+/// Effective spacing between polls is `ttl + poll_duration` because we
+/// sleep *after* each poll. For typical ohmyoled workloads
+/// (`poll_duration < 1 s`, `ttl >= 30 s`) the drift is well under the
+/// rendering cycle and not worth complicating the loop for.
+///
+/// Exits cleanly if every receiver has been dropped (panel shutdown).
 async fn background_poll<C>(
     collector: C,
     tx: watch::Sender<Option<Arc<C::Output>>>,
@@ -274,6 +293,36 @@ mod tests {
         // Exactly one poll from the background task; ten renders.
         assert_eq!(polls.load(Ordering::SeqCst), 1, "background task should poll once before sleeping for the 60 s ttl");
         assert_eq!(renders.load(Ordering::SeqCst), 10);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cached_module_repolls_after_ttl_boundary() {
+        // The cache TTL is implicit — every `ttl` seconds the background
+        // task wakes and overwrites the watch::channel with a fresh
+        // value. Verify that across multiple TTL boundaries the poll
+        // counter grows, i.e. the cache really does refresh once the
+        // configured cadence has elapsed (not just on the first tick).
+        let polls = Arc::new(AtomicUsize::new(0));
+        let renders = Arc::new(AtomicUsize::new(0));
+        let _module = Module::new(
+            CountingCollector {
+                polls: polls.clone(),
+                interval: Duration::from_millis(60),
+            },
+            CountingRenderer {
+                renders: renders.clone(),
+            },
+            Duration::from_millis(60),
+        );
+        // ~3.5 cadences. Generous margin on the assert because CI
+        // schedulers can drift; the goal is "much more than 1 poll."
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        let n = polls.load(Ordering::SeqCst);
+        assert!(
+            n >= 3,
+            "expected >=3 polls in 250ms with ttl=60ms; got {n} \
+             (cache may not be refreshing on TTL boundaries)"
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/src/lib/modules/mod.rs
+++ b/src/lib/modules/mod.rs
@@ -2,14 +2,26 @@
 //! drives the rest. Everything in the data-fetch + render pipeline is async,
 //! built on `async_trait` so the traits stay dyn-safe.
 //!
-//! To add a new module (e.g. `calendar`):
+//! ## Polling model
+//!
+//! Each module gets its own background tokio task that polls the collector
+//! on a TTL schedule (defaults to `collector.refresh_interval()`, overridable
+//! per-section via `cache_ttl_secs`). The fresh value is published into a
+//! `tokio::sync::watch` channel; the scheduler's render loop reads the
+//! current value via `borrow()` — never blocks on network.
+//!
+//! Setting `cache_ttl_secs: 0` opts the section out of the background task:
+//! the renderer calls `collector.poll().await` inline on every render. Slow
+//! (the panel stalls during the round-trip) but always shows freshest data.
+//!
+//! ## Adding a new module (e.g. `calendar`)
 //!
 //! 1. Add a `CalendarOptions` struct to `src/createjson/` with `#[derive(Deserialize)]`.
 //! 2. `#[async_trait] impl Collector for CalendarCollector` in `oledlib::api::calendar`.
 //! 3. `#[async_trait] impl Renderer for CalendarMatrix` in `oledlib::matrix::calendar`.
 //!    Optionally expose `Self::new_async()` if construction does I/O.
 //! 4. Add one match arm in [`registry::build`] that `.await`s the constructors
-//!    and pushes a `Module::new(collector, renderer)`.
+//!    and calls `Module::new(collector, renderer, ttl)`.
 //!
 //! The [`scheduler::run`] loop picks it up automatically.
 
@@ -22,25 +34,95 @@ use crate::matrix::Renderer;
 use crate::modules::error::ModuleError;
 use async_trait::async_trait;
 use ohmyoled_matrix::RGBMatrix;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::watch;
+
+/// Where this module gets its data each render:
+/// - `Cached`: a background tokio task owns the collector and writes the
+///   latest value into a `watch::channel`; this slot reads from the other
+///   end. Renders never block on network, even for slow APIs.
+/// - `Inline`: no background task (the user opted out with `cache_ttl_secs: 0`).
+///   The renderer calls `collector.poll().await` directly on each render.
+///   Always-fresh data; panel stalls for the duration of the round-trip.
+enum PollSource<C: Collector> {
+    Cached(watch::Receiver<Option<Arc<C::Output>>>),
+    Inline(C),
+}
 
 /// One module = one collector + one renderer whose `Data` types align.
 pub struct Module<C: Collector, R: Renderer<Data = C::Output>> {
-    pub collector: C,
-    pub renderer: R,
-    last_good: Option<C::Output>,
+    id: &'static str,
+    source: PollSource<C>,
+    renderer: R,
+    last_good: Option<Arc<C::Output>>,
 }
 
 impl<C, R> Module<C, R>
 where
-    C: Collector,
+    C: Collector + 'static,
     R: Renderer<Data = C::Output>,
+    C::Output: Send + Sync + 'static,
 {
-    pub fn new(collector: C, renderer: R) -> Self {
+    /// Build a module with explicit cache TTL.
+    ///
+    /// - `Duration::ZERO` ⇒ no background task; the renderer calls
+    ///   `collector.poll().await` inline on every render.
+    /// - Any other duration ⇒ spawn a background poll task that sleeps
+    ///   for `ttl` between polls; renders read the cached value.
+    pub fn new(collector: C, renderer: R, ttl: Duration) -> Self {
+        let id = collector.id();
+        if ttl.is_zero() {
+            return Self {
+                id,
+                source: PollSource::Inline(collector),
+                renderer,
+                last_good: None,
+            };
+        }
+        let (tx, rx) = watch::channel::<Option<Arc<C::Output>>>(None);
+        tokio::spawn(background_poll(collector, tx, ttl, id));
         Self {
-            collector,
+            id,
+            source: PollSource::Cached(rx),
             renderer,
             last_good: None,
         }
+    }
+}
+
+/// Background poll loop — owns the collector, writes each fresh value
+/// into `tx` as an `Arc`, sleeps `ttl` between polls. Exits cleanly if
+/// every receiver has been dropped (panel shutdown).
+async fn background_poll<C>(
+    collector: C,
+    tx: watch::Sender<Option<Arc<C::Output>>>,
+    ttl: Duration,
+    id: &'static str,
+) where
+    C: Collector + 'static,
+    C::Output: Send + Sync + 'static,
+{
+    log::debug!("[{id}] background poll task started (ttl={:?})", ttl);
+    loop {
+        if tx.is_closed() {
+            log::debug!("[{id}] watch receivers dropped; stopping poll task");
+            return;
+        }
+        let started = std::time::Instant::now();
+        match collector.poll().await {
+            Ok(data) => {
+                log::debug!(
+                    "[{id}] poll ok in {} ms",
+                    started.elapsed().as_millis()
+                );
+                let _ = tx.send(Some(Arc::new(data)));
+            }
+            Err(e) => {
+                log::warn!("[{id}] poll failed: {e}; keeping previous cached value");
+            }
+        }
+        tokio::time::sleep(ttl).await;
     }
 }
 
@@ -48,7 +130,10 @@ where
 #[async_trait]
 pub trait DynModule: Send {
     fn id(&self) -> &'static str;
-    async fn poll_and_render(&mut self, matrix: &mut RGBMatrix) -> Result<(), ModuleError>;
+    /// Render the latest cached value. Pulls from the watch::channel
+    /// (or inline-polls if the module opted out of caching) and hands
+    /// it to the renderer. Never blocks on network in the cached path.
+    async fn render_cached(&mut self, matrix: &mut RGBMatrix) -> Result<(), ModuleError>;
 }
 
 #[async_trait]
@@ -56,37 +141,45 @@ impl<C, R> DynModule for Module<C, R>
 where
     C: Collector + 'static,
     R: Renderer<Data = C::Output> + 'static,
-    C::Output: Send + Sync,
+    C::Output: Send + Sync + 'static,
 {
     fn id(&self) -> &'static str {
-        self.collector.id()
+        self.id
     }
 
-    async fn poll_and_render(&mut self, matrix: &mut RGBMatrix) -> Result<(), ModuleError> {
-        let id = self.collector.id();
-        let poll_started = std::time::Instant::now();
-        log::debug!("[{id}] poll begin");
-        match self.collector.poll().await {
-            Ok(data) => {
-                log::debug!(
-                    "[{id}] poll ok in {} ms",
-                    poll_started.elapsed().as_millis()
-                );
-                self.last_good = Some(data);
+    async fn render_cached(&mut self, matrix: &mut RGBMatrix) -> Result<(), ModuleError> {
+        let id = self.id;
+        // Pick up the latest snapshot (background or inline).
+        let snapshot: Option<Arc<C::Output>> = match &mut self.source {
+            PollSource::Cached(rx) => rx.borrow().clone(),
+            PollSource::Inline(collector) => {
+                let started = std::time::Instant::now();
+                match collector.poll().await {
+                    Ok(data) => {
+                        log::debug!(
+                            "[{id}] inline poll ok in {} ms",
+                            started.elapsed().as_millis()
+                        );
+                        Some(Arc::new(data))
+                    }
+                    Err(e) => {
+                        log::warn!("[{id}] inline poll failed: {e}; using last-good");
+                        None
+                    }
+                }
             }
-            Err(e) => {
-                log::warn!("[{id}] poll failed: {e}; using last-good data");
-            }
+        };
+        if snapshot.is_some() {
+            self.last_good = snapshot;
         }
-
         match &self.last_good {
             Some(data) => {
-                let render_started = std::time::Instant::now();
+                let started = std::time::Instant::now();
                 log::debug!("[{id}] render begin");
-                let r = self.renderer.render(matrix, data).await.map_err(Into::into);
+                let r = self.renderer.render(matrix, data.as_ref()).await.map_err(Into::into);
                 log::debug!(
                     "[{id}] render done in {} ms",
-                    render_started.elapsed().as_millis()
+                    started.elapsed().as_millis()
                 );
                 r
             }
@@ -95,5 +188,115 @@ where
                 Ok(())
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::error::ApiError;
+    use crate::matrix::error::RenderError;
+    use ohmyoled_matrix::{MatrixOptions, RGBMatrix};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    /// Collector that just counts the number of times `poll()` is called.
+    struct CountingCollector {
+        polls: Arc<AtomicUsize>,
+        interval: Duration,
+    }
+
+    #[async_trait]
+    impl Collector for CountingCollector {
+        type Output = u32;
+        fn id(&self) -> &'static str {
+            "counter"
+        }
+        fn refresh_interval(&self) -> Duration {
+            self.interval
+        }
+        async fn poll(&self) -> Result<Self::Output, ApiError> {
+            let n = self.polls.fetch_add(1, Ordering::SeqCst);
+            Ok(n as u32)
+        }
+    }
+
+    /// Renderer that just counts how often `render` was called.
+    struct CountingRenderer {
+        renders: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl Renderer for CountingRenderer {
+        type Data = u32;
+        fn id(&self) -> &'static str {
+            "counter"
+        }
+        fn cycle_duration(&self) -> Duration {
+            Duration::from_millis(1)
+        }
+        async fn render(
+            &mut self,
+            _matrix: &mut RGBMatrix,
+            _data: &u32,
+        ) -> Result<(), RenderError> {
+            self.renders.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cached_module_renders_without_polling_inline() {
+        // With a non-zero TTL, a background task owns the collector;
+        // render_cached pulls from the watch::channel and never polls
+        // inline. Verify by checking poll count stays at 1 across
+        // many renders inside the first TTL window.
+        let polls = Arc::new(AtomicUsize::new(0));
+        let renders = Arc::new(AtomicUsize::new(0));
+        let mut module = Module::new(
+            CountingCollector {
+                polls: polls.clone(),
+                interval: Duration::from_secs(60),
+            },
+            CountingRenderer {
+                renders: renders.clone(),
+            },
+            Duration::from_secs(60),
+        );
+        // Yield so the spawned poll task runs its first poll.
+        tokio::task::yield_now().await;
+        tokio::time::sleep(Duration::from_millis(1)).await;
+
+        let mut matrix = RGBMatrix::test(MatrixOptions::default());
+        for _ in 0..10 {
+            module.render_cached(&mut matrix).await.unwrap();
+        }
+        // Exactly one poll from the background task; ten renders.
+        assert_eq!(polls.load(Ordering::SeqCst), 1, "background task should poll once before sleeping for the 60 s ttl");
+        assert_eq!(renders.load(Ordering::SeqCst), 10);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn inline_module_polls_every_render() {
+        // `Duration::ZERO` opts the section out of background caching:
+        // the renderer calls collector.poll() on every render.
+        let polls = Arc::new(AtomicUsize::new(0));
+        let renders = Arc::new(AtomicUsize::new(0));
+        let mut module = Module::new(
+            CountingCollector {
+                polls: polls.clone(),
+                interval: Duration::from_secs(60),
+            },
+            CountingRenderer {
+                renders: renders.clone(),
+            },
+            Duration::ZERO,
+        );
+        let mut matrix = RGBMatrix::test(MatrixOptions::default());
+        for _ in 0..5 {
+            module.render_cached(&mut matrix).await.unwrap();
+        }
+        assert_eq!(polls.load(Ordering::SeqCst), 5);
+        assert_eq!(renders.load(Ordering::SeqCst), 5);
     }
 }

--- a/src/lib/modules/registry.rs
+++ b/src/lib/modules/registry.rs
@@ -54,7 +54,7 @@ use crate::matrix::f1::F1Matrix;
 use crate::matrix::golf::GolfMatrix;
 use crate::matrix::aurora::AuroraMatrix;
 use crate::matrix::flights::FlightsMatrix;
-use crate::matrix::hass::{HassDisplay, HassMatrix};
+use crate::matrix::hass::{HassDisplay, HassDisplayMode, HassMatrix};
 use crate::matrix::iss::IssMatrix;
 use crate::matrix::launch::LaunchMatrix;
 use crate::matrix::pihole::PiholeMatrix;
@@ -206,6 +206,11 @@ pub struct HassSection {
     /// RGB color for the alarm state row. Defaults to red.
     #[serde(default = "default_hass_alarm_color")]
     pub alarm_color: (u8, u8, u8),
+    /// Which layout to use: `"state"` (default), `"historical"`, or
+    /// `"graph"`. Historical and graph fall back to state for
+    /// non-numeric entities or until history has been fetched.
+    #[serde(default)]
+    pub display_mode: HassDisplayMode,
 }
 
 fn default_hass_nominal_color() -> (u8, u8, u8) {
@@ -637,6 +642,7 @@ async fn build_hass(s: &HassSection) -> Result<Box<dyn DynModule>, String> {
         nominal_color: ohmyoled_matrix::Color::new(s.nominal_color.0, s.nominal_color.1, s.nominal_color.2),
         alarm_color: ohmyoled_matrix::Color::new(s.alarm_color.0, s.alarm_color.1, s.alarm_color.2),
         alarm_state: s.alarm_state.clone(),
+        mode: s.display_mode,
     };
     let renderer = HassMatrix::with_fonts_async(
         crate::matrix::hass::HassFonts::default(),

--- a/src/lib/modules/registry.rs
+++ b/src/lib/modules/registry.rs
@@ -108,6 +108,11 @@ pub struct TimeSection {
     pub time_format: Option<String>,
     #[serde(default, deserialize_with = "crate::serde_helpers::null_string_as_none")]
     pub timezone: Option<String>,
+    /// Seconds between background polls. `0` ⇒ inline poll every
+    /// render cycle (slow but always fresh). Omitted ⇒ use the
+    /// collector's default `refresh_interval()`.
+    #[serde(default)]
+    pub cache_ttl_secs: Option<u64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -126,6 +131,10 @@ pub struct WeatherSection {
     pub current_location_api_key: Option<String>,
     #[serde(default)]
     pub animation: crate::matrix::weather::WeatherAnimationMode,
+    /// Seconds between background polls. `0` ⇒ inline poll. Omitted ⇒
+    /// use the collector default.
+    #[serde(default)]
+    pub cache_ttl_secs: Option<u64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -133,6 +142,8 @@ pub struct IssSection {
     pub run: bool,
     pub lat: f64,
     pub lon: f64,
+    #[serde(default)]
+    pub cache_ttl_secs: Option<u64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -140,6 +151,8 @@ pub struct QuakeSection {
     pub run: bool,
     #[serde(default)]
     pub feed: QuakeFeed,
+    #[serde(default)]
+    pub cache_ttl_secs: Option<u64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -150,6 +163,8 @@ pub struct AuroraSection {
     /// mid-latitude observers can typically see aurora.
     #[serde(default = "default_aurora_threshold")]
     pub alert_threshold: u8,
+    #[serde(default)]
+    pub cache_ttl_secs: Option<u64>,
 }
 
 fn default_aurora_threshold() -> u8 {
@@ -165,6 +180,8 @@ pub struct FlightsSection {
     /// bbox query = more credits/req against OpenSky's anonymous tier.
     #[serde(default = "default_flights_radius_km")]
     pub radius_km: f32,
+    #[serde(default)]
+    pub cache_ttl_secs: Option<u64>,
 }
 
 fn default_flights_radius_km() -> f32 {
@@ -179,6 +196,8 @@ pub struct LaunchSection {
     /// upcoming launch regardless of provider.
     #[serde(default)]
     pub agency_filter: Vec<String>,
+    #[serde(default)]
+    pub cache_ttl_secs: Option<u64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -211,6 +230,8 @@ pub struct HassSection {
     /// non-numeric entities or until history has been fetched.
     #[serde(default)]
     pub display_mode: HassDisplayMode,
+    #[serde(default)]
+    pub cache_ttl_secs: Option<u64>,
 }
 
 fn default_hass_nominal_color() -> (u8, u8, u8) {
@@ -230,6 +251,8 @@ pub struct PiholeSection {
     /// interface → Show API token). `null`/omitted = unauth.
     #[serde(default, deserialize_with = "crate::serde_helpers::null_string_as_none")]
     pub token: Option<String>,
+    #[serde(default)]
+    pub cache_ttl_secs: Option<u64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -247,6 +270,8 @@ pub struct StockSection {
     /// from CoinGecko's own `/market_chart` endpoint.
     #[serde(default)]
     pub chart: bool,
+    #[serde(default)]
+    pub cache_ttl_secs: Option<u64>,
 }
 
 /// One entry in the `sport` array. The `sport` field selects which renderer
@@ -254,16 +279,42 @@ pub struct StockSection {
 #[derive(Debug, Deserialize)]
 #[serde(tag = "sport", rename_all = "lowercase")]
 pub enum SportSection {
-    Basketball { run: bool, team_logo: crate::teams::Logo },
-    Baseball { run: bool, team_logo: crate::teams::Logo },
-    Football { run: bool, team_logo: crate::teams::Logo },
-    Hockey { run: bool, team_logo: crate::teams::Logo },
+    Basketball {
+        run: bool,
+        team_logo: crate::teams::Logo,
+        #[serde(default)]
+        cache_ttl_secs: Option<u64>,
+    },
+    Baseball {
+        run: bool,
+        team_logo: crate::teams::Logo,
+        #[serde(default)]
+        cache_ttl_secs: Option<u64>,
+    },
+    Football {
+        run: bool,
+        team_logo: crate::teams::Logo,
+        #[serde(default)]
+        cache_ttl_secs: Option<u64>,
+    },
+    Hockey {
+        run: bool,
+        team_logo: crate::teams::Logo,
+        #[serde(default)]
+        cache_ttl_secs: Option<u64>,
+    },
     Golf {
         run: bool,
         #[serde(default = "default_golf_tour")]
         tour: GolfTour,
+        #[serde(default)]
+        cache_ttl_secs: Option<u64>,
     },
-    F1 { run: bool },
+    F1 {
+        run: bool,
+        #[serde(default)]
+        cache_ttl_secs: Option<u64>,
+    },
 }
 
 impl SportSection {
@@ -274,7 +325,18 @@ impl SportSection {
             | Self::Football { run, .. }
             | Self::Hockey { run, .. }
             | Self::Golf { run, .. }
-            | Self::F1 { run } => *run,
+            | Self::F1 { run, .. } => *run,
+        }
+    }
+
+    fn cache_ttl_secs(&self) -> Option<u64> {
+        match self {
+            Self::Basketball { cache_ttl_secs, .. }
+            | Self::Baseball { cache_ttl_secs, .. }
+            | Self::Football { cache_ttl_secs, .. }
+            | Self::Hockey { cache_ttl_secs, .. }
+            | Self::Golf { cache_ttl_secs, .. }
+            | Self::F1 { cache_ttl_secs, .. } => *cache_ttl_secs,
         }
     }
 }
@@ -449,7 +511,7 @@ async fn build_time(t: &TimeSection) -> Result<Box<dyn DynModule>, String> {
     let renderer = TimeMatrix::new_async(color, None)
         .await
         .map_err(|e| format!("font: {e}"))?;
-    Ok(Box::new(Module::new(TimeCollector::new(), renderer)))
+    Ok(module_with_ttl(TimeCollector::new(), renderer, t.cache_ttl_secs))
 }
 
 async fn build_weather(w: &WeatherSection) -> Result<Box<dyn DynModule>, String> {
@@ -492,7 +554,7 @@ async fn build_weather(w: &WeatherSection) -> Result<Box<dyn DynModule>, String>
     let renderer = WeatherMatrix::new_with_animation_async(w.animation)
         .await
         .map_err(|e| format!("weather fonts: {e}"))?;
-    Ok(Box::new(Module::new(collector, renderer)))
+    Ok(module_with_ttl(collector, renderer, w.cache_ttl_secs))
 }
 
 /// Build the chart-mode (historical) module for one stock entry. For
@@ -514,7 +576,7 @@ async fn build_stock_chart(s: &StockSection) -> Result<Box<dyn DynModule>, Strin
     let renderer = StockChartMatrix::new_async()
         .await
         .map_err(|e| format!("stock_chart fonts: {e}"))?;
-    Ok(Box::new(Module::new(collector, renderer)))
+    Ok(module_with_ttl(collector, renderer, s.cache_ttl_secs))
 }
 
 async fn build_stock(s: &StockSection) -> Result<Box<dyn DynModule>, String> {
@@ -540,36 +602,37 @@ async fn build_stock(s: &StockSection) -> Result<Box<dyn DynModule>, String> {
     let renderer = StockMatrix::new_async()
         .await
         .map_err(|e| format!("stock fonts: {e}"))?;
-    Ok(Box::new(Module::new(collector, renderer)))
+    Ok(module_with_ttl(collector, renderer, s.cache_ttl_secs))
 }
 
 async fn build_sport(s: &SportSection) -> Result<Box<dyn DynModule>, String> {
+    let ttl = s.cache_ttl_secs();
     match s {
         SportSection::Basketball { team_logo, .. } => {
-            build_team_sport(SportKind::Basketball, team_logo).await
+            build_team_sport(SportKind::Basketball, team_logo, ttl).await
         }
         SportSection::Baseball { team_logo, .. } => {
-            build_team_sport(SportKind::Baseball, team_logo).await
+            build_team_sport(SportKind::Baseball, team_logo, ttl).await
         }
         SportSection::Football { team_logo, .. } => {
-            build_team_sport(SportKind::Football, team_logo).await
+            build_team_sport(SportKind::Football, team_logo, ttl).await
         }
         SportSection::Hockey { team_logo, .. } => {
-            build_team_sport(SportKind::Hockey, team_logo).await
+            build_team_sport(SportKind::Hockey, team_logo, ttl).await
         }
         SportSection::Golf { tour, .. } => {
             let collector = GolfCollector::from_espn(*tour);
             let renderer = GolfMatrix::new_async()
                 .await
                 .map_err(|e| format!("golf fonts: {e}"))?;
-            Ok(Box::new(Module::new(collector, renderer)))
+            Ok(module_with_ttl(collector, renderer, ttl))
         }
         SportSection::F1 { .. } => {
             let collector = F1Collector::from_jolpica();
             let renderer = F1Matrix::new_async()
                 .await
                 .map_err(|e| format!("f1 fonts: {e}"))?;
-            Ok(Box::new(Module::new(collector, renderer)))
+            Ok(module_with_ttl(collector, renderer, ttl))
         }
     }
 }
@@ -583,7 +646,7 @@ async fn build_iss(s: &IssSection) -> Result<Box<dyn DynModule>, String> {
     let renderer = IssMatrix::new_async()
         .await
         .map_err(|e| format!("iss fonts: {e}"))?;
-    Ok(Box::new(Module::new(collector, renderer)))
+    Ok(module_with_ttl(collector, renderer, s.cache_ttl_secs))
 }
 
 async fn build_quake(s: &QuakeSection) -> Result<Box<dyn DynModule>, String> {
@@ -592,7 +655,7 @@ async fn build_quake(s: &QuakeSection) -> Result<Box<dyn DynModule>, String> {
     let renderer = QuakeMatrix::new_async()
         .await
         .map_err(|e| format!("quake fonts: {e}"))?;
-    Ok(Box::new(Module::new(collector, renderer)))
+    Ok(module_with_ttl(collector, renderer, s.cache_ttl_secs))
 }
 
 async fn build_aurora(s: &AuroraSection) -> Result<Box<dyn DynModule>, String> {
@@ -603,7 +666,7 @@ async fn build_aurora(s: &AuroraSection) -> Result<Box<dyn DynModule>, String> {
     let renderer = AuroraMatrix::new_async()
         .await
         .map_err(|e| format!("aurora fonts: {e}"))?;
-    Ok(Box::new(Module::new(collector, renderer)))
+    Ok(module_with_ttl(collector, renderer, s.cache_ttl_secs))
 }
 
 async fn build_flights(s: &FlightsSection) -> Result<Box<dyn DynModule>, String> {
@@ -616,7 +679,7 @@ async fn build_flights(s: &FlightsSection) -> Result<Box<dyn DynModule>, String>
     let renderer = FlightsMatrix::new_async()
         .await
         .map_err(|e| format!("flights fonts: {e}"))?;
-    Ok(Box::new(Module::new(collector, renderer)))
+    Ok(module_with_ttl(collector, renderer, s.cache_ttl_secs))
 }
 
 async fn build_launch(s: &LaunchSection) -> Result<Box<dyn DynModule>, String> {
@@ -627,7 +690,7 @@ async fn build_launch(s: &LaunchSection) -> Result<Box<dyn DynModule>, String> {
     let renderer = LaunchMatrix::new_async()
         .await
         .map_err(|e| format!("launch fonts: {e}"))?;
-    Ok(Box::new(Module::new(collector, renderer)))
+    Ok(module_with_ttl(collector, renderer, s.cache_ttl_secs))
 }
 
 async fn build_hass(s: &HassSection) -> Result<Box<dyn DynModule>, String> {
@@ -650,7 +713,7 @@ async fn build_hass(s: &HassSection) -> Result<Box<dyn DynModule>, String> {
     )
     .await
     .map_err(|e| format!("hass fonts: {e}"))?;
-    Ok(Box::new(Module::new(collector, renderer)))
+    Ok(module_with_ttl(collector, renderer, s.cache_ttl_secs))
 }
 
 async fn build_pihole(s: &PiholeSection) -> Result<Box<dyn DynModule>, String> {
@@ -662,12 +725,13 @@ async fn build_pihole(s: &PiholeSection) -> Result<Box<dyn DynModule>, String> {
     let renderer = PiholeMatrix::new_async()
         .await
         .map_err(|e| format!("pihole fonts: {e}"))?;
-    Ok(Box::new(Module::new(collector, renderer)))
+    Ok(module_with_ttl(collector, renderer, s.cache_ttl_secs))
 }
 
 async fn build_team_sport(
     kind: SportKind,
     team_logo: &crate::teams::Logo,
+    cache_ttl_secs: Option<u64>,
 ) -> Result<Box<dyn DynModule>, String> {
     let collector = SportCollector::from_espn(EspnConfig {
         sport: kind,
@@ -677,5 +741,29 @@ async fn build_team_sport(
     let renderer = SportMatrix::new_async()
         .await
         .map_err(|e| format!("sport fonts: {e}"))?;
-    Ok(Box::new(Module::new(collector, renderer)))
+    Ok(module_with_ttl(collector, renderer, cache_ttl_secs))
+}
+
+/// Wrap a `(collector, renderer)` pair into a boxed `DynModule`,
+/// resolving the cache TTL from config (`cache_ttl_secs`) or the
+/// collector's own `refresh_interval()` if unset.
+///
+/// - `Some(0)` ⇒ inline polling — the renderer calls `collector.poll()`
+///   on every render. Always fresh; panel stalls during slow API calls.
+/// - `Some(n > 0)` ⇒ background task polls every `n` seconds.
+/// - `None` ⇒ background task polls at `collector.refresh_interval()`.
+fn module_with_ttl<C, R>(
+    collector: C,
+    renderer: R,
+    cache_ttl_secs: Option<u64>,
+) -> Box<dyn DynModule>
+where
+    C: crate::api::Collector + 'static,
+    R: crate::matrix::Renderer<Data = C::Output> + 'static,
+    C::Output: Send + Sync + 'static,
+{
+    let ttl = cache_ttl_secs
+        .map(std::time::Duration::from_secs)
+        .unwrap_or_else(|| collector.refresh_interval());
+    Box::new(Module::new(collector, renderer, ttl))
 }

--- a/src/lib/modules/scheduler.rs
+++ b/src/lib/modules/scheduler.rs
@@ -31,7 +31,7 @@ pub async fn run(mut matrix: RGBMatrix, mut modules: Vec<Box<dyn DynModule>>) ->
         let started = std::time::Instant::now();
         for module in modules.iter_mut() {
             log::debug!("scheduler: cycle {cycle} -> [{}]", module.id());
-            if let Err(e) = module.poll_and_render(&mut matrix).await {
+            if let Err(e) = module.render_cached(&mut matrix).await {
                 log::error!("[{}] cycle failed: {e}", module.id());
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,7 +146,7 @@ async fn main() {
 
     if matches.get_flag("dev_mode") {
         println!("Building a dev environment, replacing {target_path} with a dev config");
-        let main_json = createjson::create_json(true);
+        let main_json = createjson::create_json(true, None);
         if filelib::check_if_exists(&target_path) {
             std::fs::remove_file(&target_path).expect("Can not Remove file");
         }
@@ -173,22 +173,42 @@ async fn main() {
 
     if matches.get_flag("create_config") {
         if filelib::check_if_exists(&target_path) {
-            println!("Would you like to overwrite ({})? (y/n)", &target_path);
-            match oledlib::get_input().unwrap().to_lowercase().as_str() {
-                "y" => {
-                    let main_json = createjson::create_json(false);
+            println!(
+                "Config exists at {}. (m)erge into existing entries, (o)verwrite, or (c)ancel? [m]",
+                &target_path
+            );
+            let raw = oledlib::get_input().unwrap_or_default();
+            let choice = raw.trim().to_lowercase();
+            let choice = if choice.is_empty() { "m" } else { choice.as_str() };
+            match choice {
+                "m" | "merge" => {
+                    let existing = parse_config_file(&target_path);
+                    let main_json = createjson::create_json(false, Some(existing));
+                    if main_json.get("failure").and_then(|v| v.as_bool()).unwrap_or(false) {
+                        return;
+                    }
+                    std::fs::remove_file(&target_path).expect("Can not Remove file");
+                    ensure_config_dir(&target_path);
+                    config_io::write(&target_path, &main_json).expect("write failed");
+                    println!("Updated config at {target_path}");
+                }
+                "o" | "overwrite" => {
+                    let main_json = createjson::create_json(false, None);
+                    if main_json.get("failure").and_then(|v| v.as_bool()).unwrap_or(false) {
+                        return;
+                    }
                     std::fs::remove_file(&target_path).expect("Can not Remove file");
                     ensure_config_dir(&target_path);
                     config_io::write(&target_path, &main_json).expect("write failed");
                     println!("Wrote changes to File: {target_path}");
                 }
                 _ => {
-                    println!("Exiting...");
-                    std::process::exit(1)
+                    println!("Cancelled — config not changed");
+                    std::process::exit(0)
                 }
             }
         } else {
-            let main_json = createjson::create_json(false);
+            let main_json = createjson::create_json(false, None);
             ensure_config_dir(&target_path);
             config_io::write(&target_path, &main_json).expect("write failed");
         }

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -46,7 +46,8 @@ use oledlib::matrix::f1::{F1Fonts, F1Matrix};
 use oledlib::matrix::golf::{GolfFonts, GolfMatrix};
 use oledlib::matrix::aurora::{AuroraFonts, AuroraMatrix};
 use oledlib::matrix::flights::{FlightsFonts, FlightsMatrix};
-use oledlib::matrix::hass::{HassDisplay, HassFonts, HassMatrix};
+use oledlib::api::hass::HassSample;
+use oledlib::matrix::hass::{HassDisplay, HassDisplayMode, HassFonts, HassMatrix};
 use oledlib::matrix::iss::{IssFonts, IssMatrix};
 use oledlib::matrix::launch::{LaunchFonts, LaunchMatrix};
 use oledlib::matrix::pihole::{PiholeFonts, PiholeMatrix};
@@ -446,38 +447,74 @@ async fn preview_launch(matrix: &mut RGBMatrix, fonts: &Path) -> Result<(), Stri
 }
 
 async fn preview_hass(matrix: &mut RGBMatrix, fonts: &Path) -> Result<(), String> {
-    // Alarm-state defaults to "open" so the binary-sensor cycle entry
-    // demonstrates the color flip. Other cycle entries don't match the
-    // alarm, so they render in the nominal green.
-    let mut r = HassMatrix::with_fonts_async(
-        HassFonts {
-            body: fonts.join("04B_03B_.TTF"),
-        },
-        HassDisplay {
-            alarm_state: Some("open".into()),
-            ..HassDisplay::default()
-        },
-    )
-    .await?;
+    // Cycle through the three display modes: state (current), historical
+    // (recent past samples), graph (sparkline). Each mode gets its own
+    // matrix instance because `display.mode` is set at construction.
+    let make = |mode: HassDisplayMode| -> Result<HassMatrix, String> {
+        HassMatrix::with_fonts(
+            HassFonts {
+                body: fonts.join("04B_03B_.TTF"),
+            },
+            HassDisplay {
+                alarm_state: Some("open".into()),
+                mode,
+                ..HassDisplay::default()
+            },
+        )
+    };
+    let mut state_r = make(HassDisplayMode::State)?;
+    let mut hist_r = make(HassDisplayMode::Historical)?;
+    let mut graph_r = make(HassDisplayMode::Graph)?;
+
     let now = chrono::Utc::now();
     let entity = |state: &str, unit: Option<&str>, label: &str, age_secs: i64| HassEntity {
         state: state.into(),
         unit: unit.map(str::to_string),
         label: label.into(),
         last_changed: now - chrono::Duration::seconds(age_secs),
+        history: vec![],
     };
-    // Cycle: numeric sensor, binary door (alarm tripped), binary motion (idle),
-    // unavailable (edge case).
-    let cycle = [
-        entity("72.4", Some("°F"), "KITCHEN", 12),
-        entity("open", None, "GARAGE", 14 * 60),
-        entity("off", None, "MOTION", 35),
-        entity("unavailable", None, "OFFICE LIGHT", 5),
+    // Fake history for the numeric kitchen sensor — gentle warm-up
+    // through the morning, plotted across the sparkline.
+    let trend: Vec<f64> = (0..16)
+        .map(|i| 68.0 + (i as f64 * 0.3) + ((i as f64 * 0.4).sin() * 0.4))
+        .collect();
+    let history: Vec<HassSample> = trend
+        .iter()
+        .enumerate()
+        .map(|(i, v)| HassSample {
+            at: now - chrono::Duration::seconds((trend.len() - i) as i64 * 60),
+            value: *v,
+        })
+        .collect();
+
+    let kitchen_state = entity("72.4", Some("°F"), "KITCHEN", 12);
+    let kitchen_hist = HassEntity { history: history.clone(), ..kitchen_state.clone() };
+    let garage = entity("open", None, "GARAGE", 14 * 60);
+    let motion = entity("off", None, "MOTION", 35);
+    let unavail = entity("unavailable", None, "OFFICE LIGHT", 5);
+
+    // Cycle: state mode on a numeric sensor → historical view of the same
+    // sensor → graph view of the same sensor → state mode on assorted
+    // non-numeric entities so the user can see all three modes plus the
+    // existing alarm-flip and unavailable paths.
+    let cycle: [(HassDisplayMode, &HassEntity); 6] = [
+        (HassDisplayMode::State,      &kitchen_state),
+        (HassDisplayMode::Historical, &kitchen_hist),
+        (HassDisplayMode::Graph,      &kitchen_hist),
+        (HassDisplayMode::State,      &garage),
+        (HassDisplayMode::State,      &motion),
+        (HassDisplayMode::State,      &unavail),
     ];
     let mut i = 0usize;
     loop {
-        let data = &cycle[i % cycle.len()];
+        let (mode, data) = cycle[i % cycle.len()];
         i = i.wrapping_add(1);
+        let r = match mode {
+            HassDisplayMode::State => &mut state_r,
+            HassDisplayMode::Historical => &mut hist_r,
+            HassDisplayMode::Graph => &mut graph_r,
+        };
         r.render(matrix, data).await.map_err(|e| e.to_string())?;
     }
 }


### PR DESCRIPTION
- hass: three display modes (state / historical / graph) with sparkline
  + newest-sample marker ring; pixel-font ° replaced by a clean 2x2 mark via draw_text_with_degree
- stock_chart: left strip carries "AAPL  $182.34  vs $180.10" (vs price in dim grey), right cell scrolls "+1.24%  +$2.24"; marquee runs half-speed for one pass then settles to the head
- weather: UV orbit centered on the digit's actual rendered ink (new text_v_center_from_baseline font helper); band shifted to y=24-25 so the orbit's bottom rays stay visible; "mph" added to wind row
- flights: callsign marquee at half-speed for readability
- quake: panel-safe quiet text ("NO QUAKES" / "in last 24h")
- aurora: low-Kp tile now shows "CALM SKIES" instead of an empty banner