### PR TITLE
v3.6.2: render polish + cold-start data wait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "ohmyoled"
-version = "3.6.1"
+version = "3.6.2"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "ohmyoled"
-version = "3.6.1"
+version = "3.6.2"
 edition = "2021"
 default-run = "ohmyoled"
 

--- a/src/lib/matrix/f1.rs
+++ b/src/lib/matrix/f1.rs
@@ -314,13 +314,19 @@ impl F1Matrix {
             Color::new(180, 180, 180)
         };
 
-        draw_text(img, font, 0, bl, phase.color(), &label);
         let label_w = font.text_width(&label);
         let time_x = label_w + 3;
-        draw_text(img, font, time_x, bl, Color::WHITE, &time_str);
-
         let countdown_w = font.text_width(&countdown);
         let countdown_x = PANEL_W as i32 - countdown_w;
+
+        // Countdown is the priority on the right; clip the time so it
+        // slides behind the countdown when the two overlap (leave a 1px
+        // gap between them when they're close).
+        let time_clip_max = (countdown_x - 1).max(time_x);
+        draw_text(img, font, 0, bl, phase.color(), &label);
+        draw_text_in_window(
+            img, font, time_x, bl, Color::WHITE, &time_str, time_x, time_clip_max,
+        );
         draw_text(img, font, countdown_x, bl, countdown_color, &countdown);
     }
 
@@ -516,6 +522,41 @@ mod tests {
         let img_22 = m.draw_frame(&sample(true, 22), 0);
         let img_50 = m.draw_frame(&sample(true, 50), 0);
         assert_eq!(lb_pixels(&img_22), lb_pixels(&img_50));
+    }
+
+    #[test]
+    fn time_clipped_behind_countdown() {
+        // A "LIVE" phase + "16:00" time + "LIVE" countdown is the
+        // tightest case and used to bleed glyphs into each other.
+        // After the fix, the column the countdown occupies must contain
+        // only countdown pixels (no leftover time glyph stragglers).
+        let m = F1Matrix::with_fonts(repo_fonts()).expect("fonts");
+        let mut img = RgbImage::new(PANEL_W, PANEL_H);
+        let data = sample(true, 22);
+        // Pin "now" past start so phase = Live and countdown = "LIVE".
+        let now =
+            Local.with_ymd_and_hms(2026, 5, 24, 16, 30, 0).unwrap();
+        m.draw_phase_line(&mut img, &data, now);
+
+        let countdown = "LIVE";
+        let countdown_w = m.body_font.text_width(countdown);
+        let countdown_x = PANEL_W as i32 - countdown_w;
+        // Time "16:00" is white (255,255,255); countdown LIVE is F1_RED
+        // (225, 6, 0). A bled-through time pixel would have a high green
+        // channel (anything near r); a red-only countdown pixel has g
+        // far below r.
+        for y in 0..PANEL_H {
+            for x in countdown_x as u32..PANEL_W {
+                let [r, g, b] = img.get_pixel(x, y).0;
+                if r == 0 && g == 0 && b == 0 {
+                    continue;
+                }
+                assert!(
+                    g + 50 < r,
+                    "white time bled into countdown at ({x},{y}) = ({r},{g},{b})"
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/lib/matrix/weather.rs
+++ b/src/lib/matrix/weather.rs
@@ -51,6 +51,7 @@
 use crate::api::weather::model::{
     DailyForecast, HourlyForecast, Weather, WeatherIcon, WindDirection,
 };
+use crate::matrix::cells::draw_text_in_window;
 use crate::matrix::error::RenderError;
 use crate::matrix::renderer::Renderer;
 use async_trait::async_trait;
@@ -481,18 +482,18 @@ impl WeatherMatrix {
         let hum = data.current.humidity.min(100);
         self.draw_comfort_bar(
             &mut img, 0, "Humidity", &format!("{hum}%"),
-            hum as f32 / 100.0, fill_t, Color::new(7, 250, 246),
+            hum as f32 / 100.0, fill_t, Color::new(7, 250, 246), entry_frame,
         );
         let uv = data.current.uv.unwrap_or(0.0).max(0.0);
         let uv_t = (uv / 11.0).min(1.0);
         self.draw_comfort_bar(
             &mut img, 8, "UV", &format!("{}", uv.round() as i32),
-            uv_t, fill_t, uv_color(uv),
+            uv_t, fill_t, uv_color(uv), entry_frame,
         );
         let pr = data.current.precipitation_chance.min(100);
         self.draw_comfort_bar(
             &mut img, 16, "Rain", &format!("{pr}%"),
-            pr as f32 / 100.0, fill_t, Color::new(120, 200, 255),
+            pr as f32 / 100.0, fill_t, Color::new(120, 200, 255), entry_frame,
         );
         // Wind: bar fills relative to a 30 mph reference (typical strong wind).
         let wind = data.current.wind_speed.max(0.0);
@@ -504,7 +505,7 @@ impl WeatherMatrix {
         let wind_t = (wind / 30.0).min(1.0);
         self.draw_comfort_bar(
             &mut img, 24, "Wind", &format!("{} mph {wind_dir}", wind.round() as i32),
-            wind_t, fill_t, Color::new(201, 1, 253),
+            wind_t, fill_t, Color::new(201, 1, 253), entry_frame,
         );
 
         img
@@ -520,6 +521,7 @@ impl WeatherMatrix {
         fraction: f32,
         entry_t: f32,
         color: Color,
+        entry_frame: u32,
     ) {
         let body = &self.body_font;
         let baseline = top_to_baseline(y_top, body.ascent());
@@ -528,7 +530,37 @@ impl WeatherMatrix {
         // value" which looked washed out on the panel).
         let label_w = body.text_width(label);
         draw_text(img, body, 2, baseline, color, label);
-        draw_text(img, body, 2 + label_w + 3, baseline, color, value);
+        let value_x = 2 + label_w + 3;
+        let value_w = body.text_width(value);
+        let value_area_end = PANEL_W as i32;
+        let value_area_w = value_area_end - value_x;
+        if value_w <= value_area_w {
+            draw_text(img, body, value_x, baseline, color, value);
+        } else {
+            // Value overflows the right edge (typically the wind row at
+            // 3-digit speeds or 3-letter cardinal directions). Hold the
+            // value static until the bar entry animation settles, then
+            // scroll it leftward with a wrap copy so the full reading is
+            // readable across the screen's dwell.
+            const SCROLL_DELAY: u32 = 16; // ~800 ms — bar fill completes
+            const SCROLL_TICKS_PER_PX: u32 = 2;
+            let gap = 6; // blank pixels between wrap copies
+            let period = value_w + gap;
+            let scroll = if entry_frame < SCROLL_DELAY {
+                0
+            } else {
+                (((entry_frame - SCROLL_DELAY) / SCROLL_TICKS_PER_PX) as i32)
+                    .rem_euclid(period)
+            };
+            draw_text_in_window(
+                img, body, value_x - scroll, baseline, color, value,
+                value_x, value_area_end,
+            );
+            draw_text_in_window(
+                img, body, value_x - scroll + period, baseline, color, value,
+                value_x, value_area_end,
+            );
+        }
 
         // Full-panel-width 2 px bar tucked right under the baseline so the
         // bar sits at the bottom of its 8 px cell — at the old `+1` gap
@@ -1359,6 +1391,74 @@ mod tests {
         let early = m.frame_comfort(&sample_weather(), 0);
         let late = m.frame_comfort(&sample_weather(), 20);
         assert!(brightness(&late) > brightness(&early));
+    }
+
+    #[test]
+    fn comfort_wind_overflow_scrolls_and_does_not_clip() {
+        // A 3-digit wind speed plus a 3-letter cardinal pushes the value
+        // past the right edge ("100 mph WSW"). The value must (a) appear
+        // *inside* the value area, including pixels close to the right
+        // edge, and (b) move between frames after the scroll delay so
+        // the cut-off portion becomes readable.
+        let m = matrix_subtle();
+        let mut w = sample_weather();
+        w.current.wind_speed = 100.0;
+        w.current.wind_direction_deg = Some(247.5); // WSW
+
+        let right_strip_lit = |img: &RgbImage| -> u32 {
+            let mut n = 0;
+            for y in 24..32u32 {
+                for x in 56..64u32 {
+                    if img.get_pixel(x, y).0 != [0, 0, 0] {
+                        n += 1;
+                    }
+                }
+            }
+            n
+        };
+
+        let still = m.frame_comfort(&w, 0); // bar fill, value pinned
+        let moved = m.frame_comfort(&w, 80); // well past SCROLL_DELAY
+        // Far-right column must have ink in *some* frame — the scrolled
+        // text walks the value through the right edge.
+        let any_lit = right_strip_lit(&still) + right_strip_lit(&moved);
+        assert!(any_lit > 0, "scrolling wind value never reaches the right edge");
+
+        // Scroll progresses between frames: comparing two post-delay
+        // frames should yield different pixel layouts in the wind row.
+        let a = m.frame_comfort(&w, 40);
+        let b = m.frame_comfort(&w, 80);
+        let mut changed = 0usize;
+        for y in 24..32u32 {
+            for x in 0..64u32 {
+                if a.get_pixel(x, y).0 != b.get_pixel(x, y).0 {
+                    changed += 1;
+                }
+            }
+        }
+        assert!(changed > 0, "wind text didn't move between two scroll frames");
+    }
+
+    #[test]
+    fn comfort_short_wind_value_does_not_scroll() {
+        // 8 mph N fits in the value area — must stay static so we don't
+        // gratuitously scroll readable values.
+        let m = matrix_subtle();
+        let mut w = sample_weather();
+        w.current.wind_speed = 8.0;
+        w.current.wind_direction_deg = Some(0.0); // N
+        let a = m.frame_comfort(&w, 40);
+        let b = m.frame_comfort(&w, 80);
+        // Wind row pixels must be identical between two later frames.
+        for y in 24..32u32 {
+            for x in 0..64u32 {
+                assert_eq!(
+                    a.get_pixel(x, y).0,
+                    b.get_pixel(x, y).0,
+                    "short wind value scrolled unexpectedly at ({x},{y})"
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/lib/modules/mod.rs
+++ b/src/lib/modules/mod.rs
@@ -38,6 +38,13 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::watch;
 
+/// Upper bound on how long a Cached slot will block waiting for its
+/// first background poll before skipping the cycle. Only consulted on
+/// cold start (no value in the watch channel *and* no last-good
+/// fallback). Once any poll has succeeded, every subsequent render
+/// returns immediately from the channel.
+const FIRST_POLL_WAIT: Duration = Duration::from_secs(10);
+
 /// Where this module gets its data each render:
 /// - `Cached`: a background tokio task owns the collector and writes the
 ///   latest value into a `watch::channel`; this slot reads from the other
@@ -170,7 +177,33 @@ where
         let id = self.id;
         // Pick up the latest snapshot (background or inline).
         let snapshot: Option<Arc<C::Output>> = match &mut self.source {
-            PollSource::Cached(rx) => rx.borrow().clone(),
+            PollSource::Cached(rx) => {
+                let current = rx.borrow().clone();
+                if current.is_some() || self.last_good.is_some() {
+                    current
+                } else {
+                    // Cold start: the background task hasn't returned its
+                    // first poll yet (e.g. ISS / weather over a slow link).
+                    // Block this slot briefly so the tile doesn't silently
+                    // skip its first cycle. Bounded so a dead API can't
+                    // wedge the scheduler.
+                    log::debug!(
+                        "[{id}] no cached value yet; waiting up to {:?} for first poll",
+                        FIRST_POLL_WAIT
+                    );
+                    match tokio::time::timeout(FIRST_POLL_WAIT, rx.changed()).await {
+                        Ok(Ok(())) => rx.borrow_and_update().clone(),
+                        Ok(Err(_)) => None, // sender dropped — shutdown
+                        Err(_) => {
+                            log::warn!(
+                                "[{id}] first poll didn't arrive within {:?}; skipping cycle",
+                                FIRST_POLL_WAIT
+                            );
+                            None
+                        }
+                    }
+                }
+            }
             PollSource::Inline(collector) => {
                 let started = std::time::Instant::now();
                 match collector.poll().await {
@@ -323,6 +356,55 @@ mod tests {
             "expected >=3 polls in 250ms with ttl=60ms; got {n} \
              (cache may not be refreshing on TTL boundaries)"
         );
+    }
+
+    /// Collector that sleeps before returning, to simulate a slow API.
+    struct SlowCollector {
+        delay: Duration,
+        polls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl Collector for SlowCollector {
+        type Output = u32;
+        fn id(&self) -> &'static str {
+            "slow"
+        }
+        fn refresh_interval(&self) -> Duration {
+            Duration::from_secs(60)
+        }
+        async fn poll(&self) -> Result<Self::Output, ApiError> {
+            tokio::time::sleep(self.delay).await;
+            Ok(self.polls.fetch_add(1, Ordering::SeqCst) as u32)
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cached_module_waits_for_first_poll_on_cold_start() {
+        // If the background poll takes a few hundred ms to land (e.g.
+        // the ISS API), the very first scheduler tick used to find an
+        // empty watch channel and silently skip the slot. Verify the
+        // cold-start wait gives the poll time to land so the renderer
+        // actually fires on cycle 1.
+        let polls = Arc::new(AtomicUsize::new(0));
+        let renders = Arc::new(AtomicUsize::new(0));
+        let mut module = Module::new(
+            SlowCollector {
+                delay: Duration::from_millis(300),
+                polls: polls.clone(),
+            },
+            CountingRenderer {
+                renders: renders.clone(),
+            },
+            Duration::from_secs(60),
+        );
+        let mut matrix = RGBMatrix::test(MatrixOptions::default());
+        // First render hits the watch channel while the background poll
+        // is mid-sleep; the cold-start wait should keep us alive until
+        // the value lands.
+        module.render_cached(&mut matrix).await.unwrap();
+        assert_eq!(polls.load(Ordering::SeqCst), 1);
+        assert_eq!(renders.load(Ordering::SeqCst), 1, "cold-start render should not be skipped");
     }
 
     #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
- f1: clip the phase-line time behind the right-aligned countdown so the two stop blending into each other when both are wide (e.g. LIVE 16:00 LIVE). Regression test pins the worst-case layout.
- weather: scroll the comfort-screen value when it overflows the value area; in practice this fixes the wind row at 3-digit speeds / 3-letter cardinals (e.g. "100 mph WSW"). Short values stay static.
- modules: on cold start, a Cached slot whose background poll hasn't produced its first value waits up to FIRST_POLL_WAIT (10 s) before skipping. Stops slow APIs like ISS from silently losing their first scheduler cycle while still keeping a dead API from wedging things.