### PR TITLE
fix(eink+sport): de-ghost refresh, off-season staleness, logo cache, playoff context

### DIFF
--- a/crates/ohmyoled-matrix/src/eink/hardware.rs
+++ b/crates/ohmyoled-matrix/src/eink/hardware.rs
@@ -65,6 +65,14 @@ const BUSY_TIMEOUT: Duration = Duration::from_secs(30);
 /// controller latches data across chunks, matching Waveshare's `send_data2`.
 const SPI_CHUNK: usize = 4096;
 
+/// How many fast/partial refreshes to allow before forcing a full-refresh
+/// deep-clean. Partial refreshes don't fully drive the pixels, so charge and
+/// ghosting accumulate; routing every Nth tile update through a full refresh
+/// resets the panel so the image never fades. Counted across tile changes (the
+/// per-second clock tick increments it but never triggers the clean mid-dwell,
+/// so a ticking tile doesn't flash).
+const FULL_REFRESH_EVERY: u32 = 12;
+
 /// No-op chip-select for `embedded-hal-bus`: `rppal` drives the real `CE0`
 /// line per transfer, so the `SpiDevice` abstraction's CS toggling is inert.
 struct NoCs;
@@ -90,10 +98,12 @@ type EpdSpi = ExclusiveDevice<Spi, NoCs, Delay>;
 /// vs data (high).
 ///
 /// Updates use the panel's **fast/partial** refresh ([`init_part`] +
-/// [`display_partial`]) so screen changes are quick and never do the slow,
-/// flashy full-screen refresh. Each [`update`] clears to white then draws the
-/// new frame — both partial refreshes — so the previous frame's ghost is
-/// scrubbed without a full refresh.
+/// [`display_partial`]) so screen changes are quick. Each [`update`] clears to
+/// white then draws the new frame — both partial refreshes — so the previous
+/// frame's ghost is scrubbed. Partial refreshes don't fully drive the pixels,
+/// though, so every [`FULL_REFRESH_EVERY`] updates one is promoted to a full
+/// refresh ([`update_full`]) to reset accumulated ghosting before it fades the
+/// image.
 struct SevenIn5V2 {
     spi: Spi,
     rst: Out,
@@ -102,6 +112,10 @@ struct SevenIn5V2 {
     /// Whether the controller is currently in partial-update mode (`init_part`).
     /// [`clear`] re-enters full mode, so the next update re-arms partial mode.
     in_partial_mode: bool,
+    /// Fast/partial refreshes since the last full refresh. Drives the periodic
+    /// [`FULL_REFRESH_EVERY`] deep-clean so accumulated ghosting never fades the
+    /// image. Reset by any full refresh ([`update_full`]/[`clear`]).
+    partial_since_full: u32,
 }
 
 impl SevenIn5V2 {
@@ -117,6 +131,7 @@ impl SevenIn5V2 {
             dc,
             busy,
             in_partial_mode: false,
+            partial_since_full: 0,
         };
         // Full power-on setup (resolution, VCOM, TCON). Updates then switch to
         // partial mode; the first update's clear scrubs any retained image.
@@ -261,6 +276,12 @@ impl SevenIn5V2 {
     /// refreshes. The white clear scrubs the previous frame's ghost without the
     /// slow full-screen refresh.
     fn update(&mut self, packed: &[u8]) -> Result<(), String> {
+        // Periodic deep-clean: partial refreshes accumulate ghosting and fade,
+        // so every FULL_REFRESH_EVERY tile updates we route through a full
+        // refresh (which resets the counter) instead of the fast partial path.
+        if self.partial_since_full >= FULL_REFRESH_EVERY {
+            return self.update_full(packed);
+        }
         if !self.in_partial_mode {
             self.init_part()?;
             self.in_partial_mode = true;
@@ -268,6 +289,7 @@ impl SevenIn5V2 {
         let white = vec![0xFF; Self::FRAME_BYTES];
         self.display_partial(&white)?;
         self.display_partial(packed)?;
+        self.partial_since_full += 1;
         Ok(())
     }
 
@@ -280,6 +302,11 @@ impl SevenIn5V2 {
             self.init_part()?;
             self.in_partial_mode = true;
         }
+        // Count toward the deep-clean budget but never trigger it here: a
+        // ticking tile (clock, countdown) calls this every second and must not
+        // flash a full refresh mid-dwell. The accumulated count is paid off by
+        // the next per-tile `update`, which de-ghosts the ticking tile's trail.
+        self.partial_since_full = self.partial_since_full.saturating_add(1);
         self.display_partial(packed)
     }
 
@@ -292,7 +319,15 @@ impl SevenIn5V2 {
             self.init()?;
             self.in_partial_mode = false;
         }
-        self.display_full(packed)
+        // Clear to white first so the fine stipple develops on a clean substrate
+        // — a single transition pass can leave residual ghosting on detail-dense
+        // frames, which is exactly where the fade shows worst (the world maps).
+        let white = vec![0xFF; Self::FRAME_BYTES];
+        self.display_full(&white)?;
+        self.display_full(packed)?;
+        // A full refresh resets the panel; the ghosting budget starts over.
+        self.partial_since_full = 0;
+        Ok(())
     }
 
     /// Blank the panel to white with a clean full refresh. Restores full mode
@@ -302,6 +337,7 @@ impl SevenIn5V2 {
     fn clear(&mut self) -> Result<(), String> {
         self.init()?;
         self.in_partial_mode = false;
+        self.partial_since_full = 0;
         let white = vec![0xFF; Self::FRAME_BYTES];
         self.display_full(&white)
     }

--- a/examples/sport_render_check.rs
+++ b/examples/sport_render_check.rs
@@ -53,6 +53,7 @@ fn main() {
                 score: Some(100),
             },
             our_side: HomeOrAway::Home,
+            playoff_note: None,
         }),
         standings: (1..=5)
             .map(|i| StandingsEntry {

--- a/src/lib/api/f1/mod.rs
+++ b/src/lib/api/f1/mod.rs
@@ -37,12 +37,32 @@ pub struct F1Data {
     pub standings: Vec<DriverStanding>,
 }
 
+/// Furthest out a `next_race` can be and still count as the *current* upcoming
+/// race. The longest in-season gap (the summer break) is ~4 weeks; between
+/// seasons jolpica's `/next` points at the new season's opener months out, which
+/// this excludes so the winter break reads as off-season (champion banner) and
+/// the countdown doesn't tick toward a race in March.
+const NEXT_RACE_HORIZON: chrono::Duration = chrono::Duration::days(45);
+
 impl F1Data {
-    /// `true` when there's no upcoming race scheduled. Standings may still be
-    /// populated (last season's table is what jolpica returns between
-    /// seasons), so the renderer uses that to show a champion banner.
+    /// The race to actually count down to, or `None` when the only race jolpica
+    /// gave us is next season's (months out → off-season). Renderers branch on
+    /// this rather than `next_race` directly.
+    pub fn current_race(&self, now: DateTime<Local>) -> Option<&NextRace> {
+        self.next_race.as_ref().filter(|r| r.start <= now + NEXT_RACE_HORIZON)
+    }
+
+    /// `true` when there's no *current* upcoming race. Standings may still be
+    /// populated (last season's table is what jolpica returns between seasons),
+    /// so the renderer uses that to show a champion banner. Evaluated against
+    /// `now` so a far-future winter-break race reads as off-season.
+    pub fn is_offseason_at(&self, now: DateTime<Local>) -> bool {
+        self.current_race(now).is_none()
+    }
+
+    /// Convenience wrapper over [`Self::is_offseason_at`] using the wall clock.
     pub fn is_offseason(&self) -> bool {
-        self.next_race.is_none()
+        self.is_offseason_at(Local::now())
     }
 }
 
@@ -90,5 +110,51 @@ impl Collector for F1Collector {
 
     async fn poll(&self) -> Result<F1Data, ApiError> {
         self.source.poll().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn race_at(start: DateTime<Local>) -> NextRace {
+        NextRace { round: 1, name: "GP".into(), circuit: "Track".into(), start }
+    }
+
+    #[test]
+    fn imminent_race_is_current() {
+        let now = Local::now();
+        let d = F1Data {
+            season: "2026".into(),
+            next_race: Some(race_at(now + chrono::Duration::days(7))),
+            standings: vec![],
+        };
+        assert!(d.current_race(now).is_some());
+        assert!(!d.is_offseason_at(now));
+    }
+
+    #[test]
+    fn summer_break_gap_still_counts_as_current() {
+        // The longest in-season gap is ~4 weeks — must NOT read as off-season.
+        let now = Local::now();
+        let d = F1Data {
+            season: "2026".into(),
+            next_race: Some(race_at(now + chrono::Duration::days(28))),
+            standings: vec![],
+        };
+        assert!(!d.is_offseason_at(now));
+    }
+
+    #[test]
+    fn next_season_opener_reads_as_offseason() {
+        // Winter break: jolpica points at March; months out → off-season.
+        let now = Local::now();
+        let d = F1Data {
+            season: "2026".into(),
+            next_race: Some(race_at(now + chrono::Duration::days(100))),
+            standings: vec![],
+        };
+        assert!(d.current_race(now).is_none());
+        assert!(d.is_offseason_at(now));
     }
 }

--- a/src/lib/api/sport/espn.rs
+++ b/src/lib/api/sport/espn.rs
@@ -191,6 +191,26 @@ struct Competition {
     status: Option<StatusWrapper>,
     #[serde(default)]
     competitors: Vec<Competitor>,
+    /// Playoff round/game headlines (e.g. "East 1st Round - Game 5"). Present
+    /// only in the postseason; empty otherwise.
+    #[serde(default)]
+    notes: Vec<CompetitionNote>,
+    /// Playoff series state, when this game is part of a series.
+    #[serde(default)]
+    series: Option<SeriesInfo>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CompetitionNote {
+    #[serde(default)]
+    headline: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct SeriesInfo {
+    /// e.g. "Series tied 2-2" / "BOS leads 3-2". ESPN names this `summary`.
+    #[serde(default)]
+    summary: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -345,7 +365,17 @@ fn normalize(
         } else {
             HomeOrAway::Away
         };
-        Some(NextGame { start, status, home, away, our_side })
+        // Postseason context: the round/game headline, plus the series score
+        // when present. Both are empty in the regular season → `None`.
+        let round = comp.notes.into_iter().map(|n| n.headline).find(|h| !h.is_empty());
+        let series = comp.series.map(|s| s.summary).filter(|s| !s.is_empty());
+        let playoff_note = match (round, series) {
+            (Some(r), Some(s)) => Some(format!("{r} · {s}")),
+            (Some(r), None) => Some(r),
+            (None, Some(s)) => Some(s),
+            (None, None) => None,
+        };
+        Some(NextGame { start, status, home, away, our_side, playoff_note })
     });
 
     let standings_entries = standings
@@ -464,6 +494,43 @@ mod tests {
         let json = r#"{"homeAway":"home","team":{"displayName":"X","abbreviation":"X"},"score":null}"#;
         let c: Competitor = serde_json::from_str(json).unwrap();
         assert_eq!(c.score.0, None);
+    }
+
+    #[test]
+    fn parses_playoff_round_and_series_note() {
+        // Postseason games carry a `notes` headline and a `series` block.
+        let team_json = r#"
+        {"team":{"displayName":"Boston Celtics","abbreviation":"BOS","record":{"items":[{"summary":"4-2"}]},
+          "nextEvent":[{
+            "date":"2026-05-12T23:30Z",
+            "competitions":[{
+              "status":{"type":{"state":"pre","completed":false,"description":"Scheduled"}},
+              "notes":[{"headline":"East Semifinals - Game 5"}],
+              "series":{"summary":"Series tied 2-2"},
+              "competitors":[
+                {"homeAway":"home","team":{"displayName":"Boston Celtics","abbreviation":"BOS"},"score":null},
+                {"homeAway":"away","team":{"displayName":"New York Knicks","abbreviation":"NYK"},"score":null}
+              ]
+            }]
+          }]
+        }}"#;
+        let team: TeamDetailResponse = serde_json::from_str(team_json).unwrap();
+        let standings: StandingsResponse = serde_json::from_str(r#"{"children":[]}"#).unwrap();
+        let d = normalize(SportKind::Basketball, "Boston Celtics", team, standings).unwrap();
+        let ng = d.next_game.expect("next_game");
+        assert_eq!(
+            ng.playoff_note.as_deref(),
+            Some("East Semifinals - Game 5 · Series tied 2-2")
+        );
+    }
+
+    #[test]
+    fn regular_season_game_has_no_playoff_note() {
+        // No `notes`/`series` → regular season → note stays None.
+        let team: TeamDetailResponse = serde_json::from_str(TEAM_FIXTURE).unwrap();
+        let standings: StandingsResponse = serde_json::from_str(STANDINGS_FIXTURE).unwrap();
+        let d = normalize(SportKind::Basketball, "Boston Celtics", team, standings).unwrap();
+        assert!(d.next_game.unwrap().playoff_note.is_none());
     }
 
     #[test]

--- a/src/lib/api/sport/model.rs
+++ b/src/lib/api/sport/model.rs
@@ -87,6 +87,39 @@ pub struct NextGame {
     pub away: TeamSide,
     /// Which side is *our* configured team.
     pub our_side: HomeOrAway,
+    /// Playoff context from ESPN — a round/game headline (e.g. "East
+    /// Semifinals Game 5") optionally followed by the series score ("Series
+    /// tied 2-2"). `None` for regular-season games, so renderers show it only
+    /// in the postseason.
+    pub playoff_note: Option<String>,
+}
+
+/// How long after a final whistle we keep showing the score before treating the
+/// slot as "no current game". Covers the gap between playoff series too.
+const RECENT_FINAL_GRACE: chrono::Duration = chrono::Duration::days(2);
+
+/// How far out a scheduled game can be and still count as the team's *current*
+/// next game. In-season the next game is always days away (bye weeks ≤ 14d);
+/// between seasons ESPN's `next_event` points months out, which this excludes.
+const UPCOMING_HORIZON: chrono::Duration = chrono::Duration::days(21);
+
+impl NextGame {
+    /// Whether this game is worth showing *now* as the team's current game.
+    ///
+    /// ESPN's team `next_event` doesn't go empty in the off-season — it keeps
+    /// returning the last final score (for weeks) or the first game of next
+    /// season (months out). Both render as a misleading "current" scoreboard, so
+    /// we treat a game as current only when it's actually live, imminent, or just
+    /// finished.
+    pub fn is_current(&self, now: DateTime<Local>) -> bool {
+        match self.status {
+            GameStatus::InProgress => true,
+            GameStatus::Scheduled => {
+                self.start <= now + UPCOMING_HORIZON && self.start >= now - RECENT_FINAL_GRACE
+            }
+            GameStatus::Final | GameStatus::Postponed => self.start >= now - RECENT_FINAL_GRACE,
+        }
+    }
 }
 
 /// One row in the league standings table.
@@ -109,10 +142,23 @@ pub struct SportData {
 }
 
 impl SportData {
-    /// `true` when there's no upcoming game and no standings to scroll — the
-    /// renderer falls back to a "{Sport} Offseason" placeholder.
+    /// The game to actually display, or `None` when the only game ESPN gave us
+    /// is stale (off-season). Renderers must branch on this rather than on
+    /// `next_game` directly so a weeks-old final score doesn't read as current.
+    pub fn current_game(&self, now: DateTime<Local>) -> Option<&NextGame> {
+        self.next_game.as_ref().filter(|g| g.is_current(now))
+    }
+
+    /// `true` when there's no *current* game and no standings to scroll — the
+    /// renderer falls back to a "{Sport} Offseason" placeholder. Evaluated
+    /// against `now` so a stale `next_event` from ESPN reads as off-season.
+    pub fn is_offseason_at(&self, now: DateTime<Local>) -> bool {
+        self.current_game(now).is_none() && self.standings.is_empty()
+    }
+
+    /// Convenience wrapper over [`Self::is_offseason_at`] using the wall clock.
     pub fn is_offseason(&self) -> bool {
-        self.next_game.is_none() && self.standings.is_empty()
+        self.is_offseason_at(Local::now())
     }
 }
 
@@ -140,5 +186,94 @@ mod tests {
             standings: vec![],
         };
         assert!(d.is_offseason());
+    }
+
+    fn side(name: &str) -> TeamSide {
+        TeamSide { name: name.into(), abbreviation: name.into(), logo_url: None, score: Some(0) }
+    }
+
+    fn game(start: DateTime<Local>, status: GameStatus) -> NextGame {
+        NextGame {
+            start,
+            status,
+            home: side("A"),
+            away: side("B"),
+            our_side: HomeOrAway::Home,
+            playoff_note: None,
+        }
+    }
+
+    fn data_with(game: Option<NextGame>, standings: bool) -> SportData {
+        SportData {
+            api: SportApiSource::Espn,
+            sport: SportKind::Basketball,
+            team_name: "A".into(),
+            record: "1-0".into(),
+            next_game: game,
+            standings: if standings {
+                vec![StandingsEntry { position: 1, team_name: "A".into() }]
+            } else {
+                vec![]
+            },
+        }
+    }
+
+    #[test]
+    fn in_progress_is_always_current() {
+        let now = Local::now();
+        // Even a weirdly-dated live game shows — the league is clearly active.
+        let g = game(now - chrono::Duration::days(40), GameStatus::InProgress);
+        assert!(g.is_current(now));
+    }
+
+    #[test]
+    fn imminent_scheduled_is_current_but_far_future_is_not() {
+        let now = Local::now();
+        assert!(game(now + chrono::Duration::days(3), GameStatus::Scheduled).is_current(now));
+        // Next season's opener months out — off-season, not a current game.
+        assert!(!game(now + chrono::Duration::days(90), GameStatus::Scheduled).is_current(now));
+    }
+
+    #[test]
+    fn recent_final_is_current_but_stale_final_is_not() {
+        let now = Local::now();
+        // Just-finished game: keep the score up briefly.
+        assert!(game(now - chrono::Duration::hours(6), GameStatus::Final).is_current(now));
+        // A weeks-old final is what ESPN serves all off-season — must read stale.
+        assert!(!game(now - chrono::Duration::days(20), GameStatus::Final).is_current(now));
+    }
+
+    #[test]
+    fn stale_final_reads_as_offseason() {
+        let now = Local::now();
+        let stale = game(now - chrono::Duration::days(30), GameStatus::Final);
+        let d = data_with(Some(stale), false);
+        // The bug: next_game is Some, but it's stale → no current game → off-season.
+        assert!(d.current_game(now).is_none());
+        assert!(d.is_offseason_at(now));
+    }
+
+    #[test]
+    fn playoff_series_active_keeps_showing_games() {
+        let now = Local::now();
+        // Mid-series: next game is a couple days out → current.
+        let g = game(now + chrono::Duration::days(2), GameStatus::Scheduled);
+        let d = data_with(Some(g), true);
+        assert!(d.current_game(now).is_some());
+        assert!(!d.is_offseason_at(now));
+    }
+
+    #[test]
+    fn knocked_out_team_falls_to_offseason_after_grace() {
+        let now = Local::now();
+        // Team lost its elimination game; ESPN serves only that final, no next.
+        // Within the grace window the final still shows…
+        let just_lost = game(now - chrono::Duration::hours(12), GameStatus::Final);
+        assert!(data_with(Some(just_lost), false).current_game(now).is_some());
+        // …but a few days after elimination there is no current game.
+        let eliminated = game(now - chrono::Duration::days(5), GameStatus::Final);
+        let d = data_with(Some(eliminated), false);
+        assert!(d.current_game(now).is_none());
+        assert!(d.is_offseason_at(now));
     }
 }

--- a/src/lib/matrix/eink/f1.rs
+++ b/src/lib/matrix/eink/f1.rs
@@ -112,7 +112,8 @@ impl EinkF1Matrix {
         let m = margin(w);
         let cx = wi / 2;
 
-        let right = match &data.next_race {
+        let current_race = data.current_race(now);
+        let right = match current_race {
             Some(r) => format!("ROUND {}", r.round),
             None => "OFF-SEASON".to_string(),
         };
@@ -121,7 +122,7 @@ impl EinkF1Matrix {
         // Standings occupy the bottom; the race/champion banner the top.
         let standings_top = if data.standings.is_empty() { hi } else { hi - hi * 46 / 100 };
 
-        match &data.next_race {
+        match current_race {
             Some(race) => self.draw_race(&mut img, race, now, content_top, standings_top, fg),
             None => self.draw_offseason(&mut img, data, content_top, standings_top, fg),
         }

--- a/src/lib/matrix/eink/sport.rs
+++ b/src/lib/matrix/eink/sport.rs
@@ -37,7 +37,9 @@ use crate::matrix::error::RenderError;
 use async_trait::async_trait;
 use image::imageops::FilterType;
 use image::RgbImage;
-use std::collections::HashMap;
+use chrono::Local;
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
 use ohmyoled_matrix::graphics::{draw_text, Font};
 use ohmyoled_matrix::{Color, EinkDisplay};
 use std::path::{Path, PathBuf};
@@ -67,9 +69,16 @@ pub struct EinkSportMatrix {
     score: Font,
     status: Font,
     row: Font,
-    /// Fetched + resized team logos, keyed by team name. Populated lazily in
-    /// `render`; `frame` draws from it (abbreviation box on a miss).
-    logo_cache: HashMap<String, RgbImage>,
+    /// Fetched + resized team logos, keyed by team name. Populated by a
+    /// background task spawned from `render` (never on the render path); `frame`
+    /// draws from it (abbreviation box on a miss). Shared (`Arc<Mutex<…>>`) so
+    /// the spawned fetch can insert without blocking the display. A `std::Mutex`
+    /// is fine here — the guard is only ever held for a `get`/`insert`, never
+    /// across an `.await` — and `frame` is sync so it can't await a tokio lock.
+    logo_cache: Arc<Mutex<HashMap<String, RgbImage>>>,
+    /// Team names with a logo fetch currently in flight, so at most one task is
+    /// spawned per team even while the fetch is still pending.
+    logo_inflight: Arc<Mutex<HashSet<String>>>,
 }
 
 impl EinkSportMatrix {
@@ -90,23 +99,37 @@ impl EinkSportMatrix {
             score: Font::load_ttf(&paths.body, scaled_px(96.0, h))?,
             status: Font::load_ttf(&paths.body, scaled_px(26.0, h))?,
             row: Font::load_ttf(&paths.body, scaled_px(22.0, h))?,
-            logo_cache: HashMap::new(),
+            logo_cache: Arc::new(Mutex::new(HashMap::new())),
+            logo_inflight: Arc::new(Mutex::new(HashSet::new())),
         })
     }
 
-    /// Fetch + decode + resize a team's logo into the cache (idempotent). A
-    /// miss or failure leaves the renderer to draw the abbreviation box.
-    async fn ensure_logo(&mut self, side: &TeamSide) {
-        if self.logo_cache.contains_key(&side.name) {
+    /// Kick off a background fetch of a team's logo into the shared cache.
+    /// Returns immediately — never blocks the render path on the network. At
+    /// most one task is spawned per team (in-flight guard); a miss or failure
+    /// just leaves `frame` to draw the abbreviation box until the logo lands.
+    fn prefetch_logo(&self, side: &TeamSide) {
+        let Some(url) = side.logo_url.clone() else { return };
+        let name = side.name.clone();
+        // Already cached → nothing to do.
+        if self.logo_cache.lock().unwrap().contains_key(&name) {
             return;
         }
-        let Some(url) = side.logo_url.clone() else { return };
-        match fetch_logo(&url).await {
-            Ok(logo) => {
-                self.logo_cache.insert(side.name.clone(), logo);
-            }
-            Err(e) => log::warn!("eink sport: logo fetch failed for {} ({url}): {e}", side.name),
+        // Claim the in-flight slot; bail if another task is already fetching it.
+        if !self.logo_inflight.lock().unwrap().insert(name.clone()) {
+            return;
         }
+        let cache = Arc::clone(&self.logo_cache);
+        let inflight = Arc::clone(&self.logo_inflight);
+        tokio::spawn(async move {
+            match fetch_logo(&url).await {
+                Ok(logo) => {
+                    cache.lock().unwrap().insert(name.clone(), logo);
+                }
+                Err(e) => log::warn!("eink sport: logo fetch failed for {name} ({url}): {e}"),
+            }
+            inflight.lock().unwrap().remove(&name);
+        });
     }
 
     pub async fn with_fonts_async(paths: EinkSportFonts, dims: (u32, u32)) -> Result<Self, String> {
@@ -128,7 +151,7 @@ impl EinkSportMatrix {
 
         let standings_top = if data.standings.is_empty() { hi } else { hi - hi * 50 / 100 };
 
-        match &data.next_game {
+        match data.current_game(Local::now()) {
             Some(game) => self.draw_scoreboard(&mut img, game, content_top, standings_top, fg),
             None => {
                 let label = if data.standings.is_empty() {
@@ -160,6 +183,13 @@ impl EinkSportMatrix {
         // Everything hangs off the band's vertical center so the scoreboard
         // fills the space rather than hugging the top.
         let score_cy = top + band_h / 2;
+
+        // Playoff context (round/game headline + series score) pinned to the top
+        // of the band. Absent in the regular season, so this is postseason-only.
+        if let Some(note) = &game.playoff_note {
+            let note = fit_text(&self.status, &note.to_uppercase(), wi - 2 * m);
+            center_text(img, &self.status, cx, top + self.status.ascent(), fg, &note);
+        }
 
         // Team crest (logo if fetched, else an abbreviation box) + name,
         // vertically centered as a unit on the score line.
@@ -205,8 +235,9 @@ impl EinkSportMatrix {
     /// box with the abbreviation.
     fn draw_crest(&self, img: &mut RgbImage, cx: i32, box_top: i32, box_w: i32, side: &TeamSide, fg: Color) {
         let bx = cx - box_w / 2;
-        if let Some(logo) = self.logo_cache.get(&side.name) {
-            draw_logo_silhouette(img, logo, bx, box_top, box_w, fg);
+        let cached = self.logo_cache.lock().unwrap().get(&side.name).cloned();
+        if let Some(logo) = cached {
+            draw_logo_silhouette(img, &logo, bx, box_top, box_w, fg);
         } else {
             rect(img, bx, box_top, box_w, box_w, fg);
             center_text(img, &self.abbr, cx, box_top + box_w / 2 + self.abbr.ascent() / 2, fg, &side.abbreviation);
@@ -277,11 +308,12 @@ impl EinkRenderer for EinkSportMatrix {
     }
 
     async fn render(&mut self, display: &mut EinkDisplay, data: &SportData) -> Result<(), RenderError> {
-        // Fetch both teams' logos (cached) before composing.
-        if let Some(game) = &data.next_game {
-            let (home, away) = (game.home.clone(), game.away.clone());
-            self.ensure_logo(&home).await;
-            self.ensure_logo(&away).await;
+        // Kick off logo fetches in the background — never block the panel on
+        // the network. `frame` draws the abbreviation box until a logo lands.
+        // Only for a current game (off-season has no scoreboard to fill).
+        if let Some(game) = data.current_game(Local::now()) {
+            self.prefetch_logo(&game.home);
+            self.prefetch_logo(&game.away);
         }
         let img = self.frame(data, display.width(), display.height());
         display.show(&img);
@@ -290,10 +322,47 @@ impl EinkRenderer for EinkSportMatrix {
     }
 }
 
-/// HTTP fetch + decode + resize a logo to `LOGO_PX` square, composited onto a
-/// white background (so transparency reads as background for the silhouette).
+/// Square size every cached logo is normalized to.
+const LOGO_PX: u32 = 120;
+
+/// On-disk cache directory for processed logos. Honors `XDG_CACHE_HOME`, then
+/// `$HOME/.cache`, then `/tmp`. Team logos never change, so once a processed
+/// crest is written here it's reused across restarts with no network at all.
+fn logo_cache_dir() -> PathBuf {
+    let base = std::env::var_os("XDG_CACHE_HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".cache")))
+        .unwrap_or_else(|| PathBuf::from("/tmp"));
+    base.join("ohmyoled").join("logos")
+}
+
+/// Stable cache path for a logo URL at the current size. `DefaultHasher::new()`
+/// is fixed-seed (not `RandomState`), so the name is deterministic across runs.
+fn logo_cache_path(url: &str) -> PathBuf {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    url.hash(&mut h);
+    LOGO_PX.hash(&mut h);
+    logo_cache_dir().join(format!("{:016x}.png", h.finish()))
+}
+
+/// Load a processed logo: disk cache first (static, so a hit means zero
+/// network), otherwise HTTP fetch → decode → resize → composite, then write it
+/// back to disk so every subsequent run (this team, forever) is a disk hit.
 async fn fetch_logo(url: &str) -> Result<RgbImage, String> {
-    const LOGO_PX: u32 = 120;
+    let path = logo_cache_path(url);
+
+    // Disk hit — reuse the already-processed crest, no network.
+    let read_path = path.clone();
+    if let Ok(Ok(img)) = tokio::task::spawn_blocking(move || {
+        image::open(&read_path).map(|i| i.to_rgb8())
+    })
+    .await
+    {
+        log::debug!("eink sport: logo disk-cache hit for {url}");
+        return Ok(img);
+    }
+
     let bytes = shared_client()
         .get(url)
         .send()
@@ -313,6 +382,16 @@ async fn fetch_logo(url: &str) -> Result<RgbImage, String> {
             let a = p[3] as f32 / 255.0;
             let blend = |c: u8| (c as f32 * a + 255.0 * (1.0 - a)).round() as u8;
             out.put_pixel(x, y, image::Rgb([blend(p[0]), blend(p[1]), blend(p[2])]));
+        }
+        // Persist the processed crest (best-effort — a cache write failure must
+        // never fail the render; we just re-fetch next time).
+        if let Some(dir) = path.parent() {
+            let saved = std::fs::create_dir_all(dir)
+                .map_err(|e| e.to_string())
+                .and_then(|_| out.save(&path).map_err(|e| e.to_string()));
+            if let Err(e) = saved {
+                log::debug!("eink sport: logo cache write failed ({}): {e}", path.display());
+            }
         }
         Ok(out)
     })
@@ -355,6 +434,7 @@ mod tests {
                 home: side("76ers", "PHI", Some(88)),
                 away: side("Celtics", "BOS", Some(81)),
                 our_side: HomeOrAway::Home,
+                playoff_note: Some("EAST 1ST ROUND - Game 5 · Series tied 2-2".into()),
             }),
             standings: standings(),
         }

--- a/src/lib/matrix/sport.rs
+++ b/src/lib/matrix/sport.rs
@@ -169,7 +169,7 @@ impl Renderer for SportMatrix {
             return Ok(());
         }
 
-        if let Some(ng) = &data.next_game {
+        if let Some(ng) = data.current_game(Local::now()) {
             self.ensure_logo(&ng.home).await;
             self.ensure_logo(&ng.away).await;
         }
@@ -196,7 +196,9 @@ impl SportMatrix {
     /// Render one composed frame at the given scroll offset.
     pub fn draw_frame(&self, data: &SportData, xpos: i32) -> RgbImage {
         let mut img = RgbImage::new(PANEL_W, PANEL_H);
-        if let Some(ng) = &data.next_game {
+        // Only the *current* game gets a scoreboard — a stale ESPN `next_event`
+        // (weeks-old final / next-season opener) falls through to standings only.
+        if let Some(ng) = data.current_game(Local::now()) {
             self.draw_top(&mut img, ng, xpos);
             self.draw_middle(&mut img, ng);
         }
@@ -281,7 +283,7 @@ impl SportMatrix {
         let font = &self.body_font;
         let baseline = top_to_baseline(25, font.ascent());
 
-        let text = if data.standings.is_empty() {
+        let standings_text = if data.standings.is_empty() {
             format!("{} ({}) {}", data.team_name, data.record, data.sport.display_name())
         } else {
             let mut parts: Vec<String> = data
@@ -291,6 +293,13 @@ impl SportMatrix {
                 .collect();
             parts.push(format!("({})", data.record));
             parts.join("  ")
+        };
+
+        // In the postseason, lead the marquee with the playoff round/series note
+        // (no spare rows on a 64×32 panel, so it shares the bottom scroll).
+        let text = match data.current_game(Local::now()).and_then(|g| g.playoff_note.as_deref()) {
+            Some(note) => format!("{note}  ·  {standings_text}"),
+            None => standings_text,
         };
 
         // Text width ≈ 4px/char for 04B_03B; loop scroll modulo total width.
@@ -452,7 +461,6 @@ fn decode_and_resize(bytes: &[u8]) -> Result<RgbImage, String> {
 mod tests {
     use super::*;
     use crate::api::sport::model::{SportApiSource, StandingsEntry};
-    use chrono::TimeZone;
     use std::path::PathBuf;
 
     fn repo_fonts() -> SportFonts {
@@ -466,7 +474,9 @@ mod tests {
     fn make_data(with_game: bool, with_standings: bool, status: GameStatus) -> SportData {
         let next_game = if with_game {
             Some(NextGame {
-                start: Local.with_ymd_and_hms(2024, 6, 15, 19, 30, 0).unwrap(),
+                // Near-now so the game counts as *current* (not stale); the exact
+                // wall-clock instant doesn't matter to these layout assertions.
+                start: Local::now(),
                 status,
                 home: TeamSide {
                     name: "Boston Celtics".into(),
@@ -481,6 +491,7 @@ mod tests {
                     score: Some(100),
                 },
                 our_side: HomeOrAway::Home,
+                playoff_note: None,
             })
         } else {
             None

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -477,6 +477,7 @@ async fn preview_eink_sport(display: &mut EinkDisplay, fonts: &Path) -> Result<(
             home: TeamSide { name: "76ers".into(), abbreviation: "PHI".into(), logo_url: None, score: Some(88) },
             away: TeamSide { name: "Celtics".into(), abbreviation: "BOS".into(), logo_url: None, score: Some(81) },
             our_side: HomeOrAway::Home,
+            playoff_note: Some("EAST 1ST ROUND - Game 5 · Series tied 2-2".into()),
         }),
         standings,
     };
@@ -675,6 +676,7 @@ async fn preview_sport(matrix: &mut RGBMatrix, fonts: &Path) -> Result<(), Strin
                 score: Some(100),
             },
             our_side: HomeOrAway::Home,
+            playoff_note: None,
         }),
         standings: (1..=5)
             .map(|i| StandingsEntry {


### PR DESCRIPTION
## Summary

Fixes two reported e-ink bugs plus a stack of sport-data correctness follow-ups, all on the e-paper + LED sport/F1 paths.

### Bugs
- **E-ink fade/ghosting over time** (`crates/ohmyoled-matrix/src/eink/hardware.rs`): partial refreshes on the 7in5_v2 accumulate ghosting and fade. Every 12th partial refresh is now promoted to a full de-ghost, and `update_full` (the world maps) clears to white before drawing so the fine stipple develops crisp. Ticking tiles (clock/countdown) count toward the budget but never flash mid-dwell.
- **Panel freeze while waiting on API** (`src/lib/matrix/eink/sport.rs`): team logos were fetched on the render path. They now load in a background task into a shared `Arc<Mutex>` cache; `render()` never awaits the network and draws the abbreviation box until a logo lands.

### Off-season correctness (all team sports + F1)
- ESPN / jolpica keep serving a stale `next_event` / `next_race` between seasons, so a weeks-old final or a months-out opener rendered as "current."
- Added staleness-aware `current_game(now)` / `current_race(now)`: a game counts only when live, ≤21d out, or finished ≤2d ago; an F1 race counts only within a 45-day horizon (summer break still counts; winter break reads as off-season → champion banner).
- This also makes a **knocked-out playoff team** fall to off-season after a short grace, while an active series keeps showing (21-day horizon covers between-round gaps).

### Playoff context
- ESPN's `notes[].headline` + `series.summary` (previously parsed then discarded) are surfaced as `NextGame.playoff_note` — shown on the e-ink scoreboard top band and folded into the LED bottom marquee.

### Disk-backed logo cache
- Processed crests persist to `~/.cache/ohmyoled/logos/` (XDG-aware, deterministic URL hash) so logos survive restarts with zero network after the first run.

## Tests
- 338 lib tests pass, clippy clean, full build (bin + examples) OK.
- New unit tests: staleness/elimination (`sport/model.rs`), F1 horizon (`f1/mod.rs`), playoff-note parsing (`sport/espn.rs`).

## Caveat
ESPN's playoff field names (`competitions[].notes[].headline`, `competitions[].series.summary`) are parsed defensively — all optional, so a mismatch degrades to "no note," never an error. Based on ESPN's known shape but not validated against a live postseason payload; worth eyeballing during the actual playoffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)