### PR TITLE
feat(stock-chart): intraday 1D x-axis anchored to trading session by time of day

### DIFF
--- a/src/lib/api/stock/mod.rs
+++ b/src/lib/api/stock/mod.rs
@@ -12,7 +12,7 @@ pub mod finnhub;
 pub mod model;
 pub mod yahoo;
 
-pub use model::{Direction, HistorySeries, StockApiSource, StockHistory, StockQuote};
+pub use model::{Direction, HistorySeries, StockApiSource, StockHistory, StockQuote, TradingSession};
 
 use coingecko::{CoingeckoConfig, CoingeckoProvider};
 use finnhub::{FinnhubConfig, FinnhubProvider};

--- a/src/lib/api/stock/model.rs
+++ b/src/lib/api/stock/model.rs
@@ -62,6 +62,19 @@ pub enum Direction {
     Flat,
 }
 
+/// Regular trading session bounds (epoch seconds, UTC) for an
+/// intraday window. When present alongside per-sample `times`, the
+/// renderer anchors the x-axis to `[start, end]` and positions each
+/// sample by its real timestamp instead of evenly spacing them — so a
+/// half-finished trading day fills only the elapsed half of the axis.
+#[derive(Debug, Clone, Copy)]
+pub struct TradingSession {
+    /// Session open, epoch seconds (e.g. 9:30 AM ET).
+    pub start: i64,
+    /// Session close, epoch seconds (e.g. 4:00 PM ET).
+    pub end: i64,
+}
+
 /// One period's worth of historical closes, plus the precomputed
 /// extrema. The renderer needs the extrema for autoscaling the graph
 /// — keeping them on the series saves the renderer from re-scanning
@@ -74,28 +87,97 @@ pub struct HistorySeries {
     pub closes: Vec<f64>,
     pub low: f64,
     pub high: f64,
+    /// Epoch-second timestamp for each close, parallel to `closes`.
+    /// Empty unless the provider supplied intraday timestamps (only the
+    /// 1D equity window does today) — month/year and crypto leave this
+    /// empty and fall back to even spacing.
+    pub times: Vec<i64>,
+    /// Regular trading session bounds for this window, when known. Only
+    /// meaningful together with a fully-populated `times`.
+    pub session: Option<TradingSession>,
 }
 
 impl HistorySeries {
-    /// Compute the series from raw closes; min/max scan once at
-    /// construction time. Filters out NaN samples — some providers
-    /// pad missing intervals with nulls that deserialize into NaN.
-    pub fn from_closes(raw: Vec<f64>) -> Self {
-        let closes: Vec<f64> = raw.into_iter().filter(|v| v.is_finite()).collect();
-        let (low, high) = closes
+    /// Compute the extrema for a set of closes. An empty slice yields
+    /// `(0.0, 0.0)` so the renderer's autoscale never divides by ±inf.
+    fn extrema(closes: &[f64]) -> (f64, f64) {
+        if closes.is_empty() {
+            return (0.0, 0.0);
+        }
+        closes
             .iter()
             .copied()
             .fold((f64::INFINITY, f64::NEG_INFINITY), |(lo, hi), v| {
                 (lo.min(v), hi.max(v))
-            });
-        // An empty series yields ±inf extrema — collapse to (0, 0) so
-        // the renderer's autoscale doesn't divide by ±inf.
-        let (low, high) = if closes.is_empty() {
-            (0.0, 0.0)
+            })
+    }
+
+    /// Compute the series from raw closes; min/max scan once at
+    /// construction time. Filters out NaN samples — some providers
+    /// pad missing intervals with nulls that deserialize into NaN.
+    /// Leaves `times`/`session` empty: this is the even-spacing path
+    /// used by the month/year windows and by crypto.
+    pub fn from_closes(raw: Vec<f64>) -> Self {
+        let closes: Vec<f64> = raw.into_iter().filter(|v| v.is_finite()).collect();
+        let (low, high) = Self::extrema(&closes);
+        Self {
+            closes,
+            low,
+            high,
+            times: Vec::new(),
+            session: None,
+        }
+    }
+
+    /// Build an intraday series with per-sample timestamps and the
+    /// session bounds. Filters non-finite closes in lockstep with their
+    /// timestamps so the two arrays stay aligned. If `raw_times` doesn't
+    /// match `raw_closes` in length, the timestamps are dropped and the
+    /// series degrades gracefully to even spacing.
+    pub fn from_samples(
+        raw_closes: Vec<f64>,
+        raw_times: Vec<i64>,
+        session: Option<TradingSession>,
+    ) -> Self {
+        let have_times = raw_times.len() == raw_closes.len();
+        let mut closes = Vec::with_capacity(raw_closes.len());
+        let mut times = Vec::with_capacity(raw_closes.len());
+        for (i, v) in raw_closes.into_iter().enumerate() {
+            if v.is_finite() {
+                closes.push(v);
+                if have_times {
+                    times.push(raw_times[i]);
+                }
+            }
+        }
+        let (low, high) = Self::extrema(&closes);
+        // Only keep timestamps when they're fully aligned with closes.
+        let times = if times.len() == closes.len() {
+            times
         } else {
-            (low, high)
+            Vec::new()
         };
-        Self { closes, low, high }
+        Self {
+            closes,
+            low,
+            high,
+            times,
+            session,
+        }
+    }
+
+    /// Time-anchored view of the series: `(closes, times, session)` when
+    /// this window carries aligned per-sample timestamps and session
+    /// bounds. `None` for the even-spacing windows (month/year/crypto)
+    /// or any degenerate case, which tells the renderer to fall back to
+    /// bucketing across the full width.
+    pub fn intraday(&self) -> Option<(&[f64], &[i64], TradingSession)> {
+        let session = self.session?;
+        if self.closes.len() >= 2 && self.times.len() == self.closes.len() {
+            Some((&self.closes, &self.times, session))
+        } else {
+            None
+        }
     }
 
     pub fn is_empty(&self) -> bool {
@@ -221,6 +303,53 @@ mod tests {
         assert_eq!(s.high, 0.0);
         assert_eq!(s.direction(), Direction::Flat);
         assert_eq!(s.percent_change(), 0.0);
+    }
+
+    #[test]
+    fn from_samples_keeps_times_aligned_through_nan_filter() {
+        let session = TradingSession { start: 1_000, end: 24_400 };
+        let s = HistorySeries::from_samples(
+            vec![100.0, f64::NAN, 105.0, 95.0],
+            vec![1_000, 1_300, 1_600, 1_900],
+            Some(session),
+        );
+        // NaN sample dropped along with its timestamp.
+        assert_eq!(s.closes, vec![100.0, 105.0, 95.0]);
+        assert_eq!(s.times, vec![1_000, 1_600, 1_900]);
+        let (closes, times, sess) = s.intraday().expect("intraday view");
+        assert_eq!(closes.len(), times.len());
+        assert_eq!(sess.start, 1_000);
+    }
+
+    #[test]
+    fn from_samples_drops_times_on_length_mismatch() {
+        // A timestamp array that doesn't match closes is discarded — the
+        // series degrades to even spacing rather than mis-aligning.
+        let s = HistorySeries::from_samples(
+            vec![100.0, 105.0, 95.0],
+            vec![1_000, 1_300],
+            Some(TradingSession { start: 0, end: 1 }),
+        );
+        assert!(s.times.is_empty());
+        assert!(s.intraday().is_none());
+    }
+
+    #[test]
+    fn from_closes_has_no_intraday_view() {
+        let s = HistorySeries::from_closes(vec![100.0, 105.0, 95.0]);
+        assert!(s.times.is_empty());
+        assert!(s.session.is_none());
+        assert!(s.intraday().is_none());
+    }
+
+    #[test]
+    fn intraday_needs_two_samples() {
+        let s = HistorySeries::from_samples(
+            vec![100.0],
+            vec![1_000],
+            Some(TradingSession { start: 0, end: 1 }),
+        );
+        assert!(s.intraday().is_none(), "single sample can't draw a line");
     }
 
     #[test]

--- a/src/lib/api/stock/yahoo.rs
+++ b/src/lib/api/stock/yahoo.rs
@@ -15,7 +15,7 @@
 //! - The collector returns the last successfully populated snapshot;
 //!   poll failures log and skip rather than blanking the panel.
 
-use super::model::{HistorySeries, StockApiSource, StockHistory};
+use super::model::{HistorySeries, StockApiSource, StockHistory, TradingSession};
 use crate::api::error::ApiError;
 use crate::api::http::get_json;
 use serde::Deserialize;
@@ -77,7 +77,11 @@ impl YahooProvider {
             symbol: self.symbol.to_uppercase(),
             current,
             previous_close,
-            day: day.map(|p| HistorySeries::from_closes(p.closes)).unwrap_or_else(|_| HistorySeries::from_closes(vec![])),
+            // The 1D window carries per-sample timestamps + session
+            // bounds so the renderer can lay it out by time of day.
+            day: day
+                .map(|p| HistorySeries::from_samples(p.closes, p.times, p.session))
+                .unwrap_or_else(|_| HistorySeries::from_closes(vec![])),
             month: month
                 .map(|p| HistorySeries::from_closes(p.closes))
                 .unwrap_or_else(|_| HistorySeries::from_closes(vec![])),
@@ -107,31 +111,88 @@ impl YahooProvider {
 #[derive(Debug)]
 struct ParsedWindow {
     closes: Vec<f64>,
+    /// Epoch-second timestamp per surviving close, aligned with
+    /// `closes`. Empty when Yahoo omitted the `timestamp` array (it's
+    /// present on the intraday range, absent on some delisted symbols).
+    times: Vec<i64>,
+    /// Regular trading session for the day the bars belong to. `None`
+    /// when the meta block lacks the offset or trading-period fields.
+    session: Option<TradingSession>,
     last_close: f64,
     previous_close: Option<f64>,
 }
 
-/// Pure: pull the closes out of a parsed Yahoo response. Returns
-/// `None` if the chart block is empty or absent — Yahoo serves this
-/// shape for delisted/unknown symbols.
+/// Pure: pull the closes (and, when present, their timestamps) out of a
+/// parsed Yahoo response. Returns `None` if the chart block is empty or
+/// absent — Yahoo serves that shape for delisted/unknown symbols.
 fn parse_window(raw: RawResponse) -> Option<ParsedWindow> {
     let result = raw.chart.result.into_iter().next()?;
+    let timestamps = result.timestamp;
     let quote = result.indicators.quote.into_iter().next()?;
-    let closes: Vec<f64> = quote
-        .close
-        .into_iter()
-        .flatten() // drop null gaps
-        .filter(|v| v.is_finite())
-        .collect();
+
+    // Walk closes and timestamps together so dropping a null close also
+    // drops its timestamp — the two arrays must stay index-aligned.
+    let have_times = timestamps.len() == quote.close.len();
+    let mut closes = Vec::with_capacity(quote.close.len());
+    let mut times = Vec::with_capacity(quote.close.len());
+    for (i, c) in quote.close.into_iter().enumerate() {
+        if let Some(v) = c {
+            if v.is_finite() {
+                closes.push(v);
+                if have_times {
+                    times.push(timestamps[i]);
+                }
+            }
+        }
+    }
     if closes.is_empty() {
         return None;
     }
     let last_close = *closes.last().unwrap();
+
+    // Anchor the session to the calendar day of the most recent bar.
+    let session = times
+        .last()
+        .and_then(|&last_ts| session_for_day(&result.meta, last_ts));
+
     Some(ParsedWindow {
         closes,
+        times,
+        session,
         last_close,
         previous_close: result.meta.previous_close,
     })
+}
+
+/// Derive the regular trading session (epoch seconds) for the calendar
+/// day containing `anchor_ts`. Yahoo's `currentTradingPeriod.regular`
+/// gives the canonical open/close, but its *date* rolls forward to the
+/// next session once the market closes — so we take only its
+/// **time-of-day** and re-anchor it to the day the bars actually belong
+/// to. `gmtoffset` (the exchange's UTC offset, DST-correct for that
+/// day) converts between epoch and exchange-local wall clock, so this
+/// works for non-US exchanges too without a timezone database.
+fn session_for_day(meta: &Meta, anchor_ts: i64) -> Option<TradingSession> {
+    let gmt = meta.gmtoffset?;
+    let regular = meta.current_trading_period.as_ref()?.regular.as_ref()?;
+    let open = regular.start?;
+    let close = regular.end?;
+
+    const DAY: i64 = 86_400;
+    // Seconds since exchange-local midnight for the canonical open/close.
+    let open_tod = (open + gmt).rem_euclid(DAY);
+    let close_tod = (close + gmt).rem_euclid(DAY);
+    // Exchange-local midnight of the anchor day, back in epoch seconds.
+    let local_midnight = (anchor_ts + gmt) - (anchor_ts + gmt).rem_euclid(DAY) - gmt;
+
+    let start = local_midnight + open_tod;
+    let mut end = local_midnight + close_tod;
+    // Guard against a close-before-open wrap (shouldn't happen for a
+    // normal session, but keeps the renderer's span strictly positive).
+    if end <= start {
+        end += DAY;
+    }
+    Some(TradingSession { start, end })
 }
 
 #[derive(Debug, Deserialize)]
@@ -146,12 +207,33 @@ struct Chart {
 #[derive(Debug, Deserialize)]
 struct ChartResult {
     meta: Meta,
+    /// Parallel to `indicators.quote[0].close` — epoch seconds per bar.
+    /// Absent on some payloads, so default to empty.
+    #[serde(default)]
+    timestamp: Vec<i64>,
     indicators: Indicators,
 }
 #[derive(Debug, Deserialize)]
 struct Meta {
     #[serde(default, rename = "previousClose")]
     previous_close: Option<f64>,
+    /// Exchange UTC offset in seconds (DST-correct for the day).
+    #[serde(default)]
+    gmtoffset: Option<i64>,
+    #[serde(default, rename = "currentTradingPeriod")]
+    current_trading_period: Option<CurrentTradingPeriod>,
+}
+#[derive(Debug, Deserialize)]
+struct CurrentTradingPeriod {
+    #[serde(default)]
+    regular: Option<TradingPeriod>,
+}
+#[derive(Debug, Deserialize)]
+struct TradingPeriod {
+    #[serde(default)]
+    start: Option<i64>,
+    #[serde(default)]
+    end: Option<i64>,
 }
 #[derive(Debug, Deserialize)]
 struct Indicators {
@@ -178,8 +260,13 @@ mod tests {
                     "meta": {
                         "currency": "USD",
                         "symbol": "AAPL",
-                        "previousClose": 181.10
+                        "previousClose": 181.10,
+                        "gmtoffset": -14400,
+                        "currentTradingPeriod": {
+                            "regular": { "start": 1718026200, "end": 1718049600 }
+                        }
                     },
+                    "timestamp": [1718026200, 1718026500, 1718026800, 1718027100, 1718027400],
                     "indicators": {
                         "quote": [
                             {
@@ -201,6 +288,68 @@ mod tests {
         assert_eq!(parsed.closes.len(), 4);
         assert_eq!(parsed.last_close, 182.34);
         assert_eq!(parsed.previous_close, Some(181.10));
+    }
+
+    #[test]
+    fn timestamps_drop_in_lockstep_with_null_closes() {
+        let raw: RawResponse = serde_json::from_str(FIXTURE).expect("deserialize");
+        let parsed = parse_window(raw).expect("window");
+        // The 3rd close was null → its timestamp (…26800) is dropped too.
+        assert_eq!(parsed.times.len(), parsed.closes.len());
+        assert_eq!(
+            parsed.times,
+            vec![1718026200, 1718026500, 1718027100, 1718027400]
+        );
+    }
+
+    #[test]
+    fn session_anchors_to_the_bars_own_day() {
+        // The fixture's gmtoffset is -4h (ET, DST). The regular period's
+        // start time-of-day re-anchored to the bar day must equal the
+        // first bar (the open). End must be after start.
+        let raw: RawResponse = serde_json::from_str(FIXTURE).expect("deserialize");
+        let parsed = parse_window(raw).expect("window");
+        let s = parsed.session.expect("session derived");
+        assert_eq!(s.start, 1718026200, "session start == 9:30 open bar");
+        assert!(s.end > s.start);
+        // 9:30 → 16:00 is 6.5h = 23_400s.
+        assert_eq!(s.end - s.start, 23_400);
+    }
+
+    #[test]
+    fn session_reanchors_when_trading_period_rolls_forward() {
+        // Simulate an after-hours fetch: bars are from one day but
+        // currentTradingPeriod.regular has rolled to the *next* session.
+        // We should take only its time-of-day and re-anchor to the bars.
+        let json = r#"{"chart":{"result":[{
+            "meta":{
+                "gmtoffset":-14400,
+                "currentTradingPeriod":{"regular":{"start":1718112600,"end":1718136000}}
+            },
+            "timestamp":[1718026200, 1718049600],
+            "indicators":{"quote":[{"close":[180.0, 182.0]}]}
+        }]}}"#;
+        let raw: RawResponse = serde_json::from_str(json).unwrap();
+        let parsed = parse_window(raw).expect("window");
+        let s = parsed.session.expect("session");
+        // Re-anchored to the bar day, the open lands on 9:30 of that day.
+        assert_eq!(s.start, 1718026200);
+        assert_eq!(s.end - s.start, 23_400);
+    }
+
+    #[test]
+    fn missing_meta_yields_no_session_but_still_parses() {
+        // Closes with no gmtoffset/trading-period: times still captured,
+        // session is None, and the renderer falls back to even spacing.
+        let json = r#"{"chart":{"result":[{
+            "meta":{"previousClose":100.0},
+            "timestamp":[1,2,3],
+            "indicators":{"quote":[{"close":[100.0,101.0,102.0]}]}
+        }]}}"#;
+        let raw: RawResponse = serde_json::from_str(json).unwrap();
+        let parsed = parse_window(raw).expect("window");
+        assert_eq!(parsed.times.len(), 3);
+        assert!(parsed.session.is_none());
     }
 
     #[test]

--- a/src/lib/matrix/eink/layout.rs
+++ b/src/lib/matrix/eink/layout.rs
@@ -263,6 +263,44 @@ pub fn sparkline(img: &mut RgbImage, x: i32, y: i32, w: i32, h: i32, series: &[f
     fill_rect(img, mx - 1, my - 1, 3, 3, color);
 }
 
+/// Like [`sparkline`], but each point carries its own normalized x
+/// position `fracs[i]` in `0.0..=1.0` instead of being evenly spaced.
+/// Used by the intraday (1D) stock row so a half-finished trading day
+/// fills only the elapsed portion of the plot width — the x-axis is
+/// time of day, not sample index. `series` and `fracs` must be the same
+/// length; values autoscale to the box height exactly as in `sparkline`.
+#[allow(clippy::too_many_arguments)]
+pub fn sparkline_timed(img: &mut RgbImage, x: i32, y: i32, w: i32, h: i32, series: &[f32], fracs: &[f32], color: Color) {
+    if series.len() != fracs.len() || series.len() < 2 || w < 2 || h < 1 {
+        return;
+    }
+    let (mut lo, mut hi) = (f32::INFINITY, f32::NEG_INFINITY);
+    for &v in series {
+        if v.is_finite() {
+            lo = lo.min(v);
+            hi = hi.max(v);
+        }
+    }
+    if !lo.is_finite() || !hi.is_finite() {
+        return;
+    }
+    let span = hi - lo;
+    let sx = |f: f32| x + ((w - 1) as f32 * f.clamp(0.0, 1.0)).round() as i32;
+    let sy = |v: f32| {
+        if span <= f32::EPSILON {
+            y + h / 2
+        } else {
+            y + h - 1 - ((v - lo) / span * (h - 1) as f32).round() as i32
+        }
+    };
+    for i in 1..series.len() {
+        draw_line(img, sx(fracs[i - 1]), sy(series[i - 1]), sx(fracs[i]), sy(series[i]), color);
+    }
+    // Newest-point marker rides the last sample's time position.
+    let last = series.len() - 1;
+    fill_rect(img, sx(fracs[last]) - 1, sy(series[last]) - 1, 3, 3, color);
+}
+
 /// Draw a badge — a small boxed label. `filled` inverts it (solid box with the
 /// text knocked out), which reads as a high-contrast alert on the panel.
 /// Returns the x just past the badge.

--- a/src/lib/matrix/eink/stock_chart.rs
+++ b/src/lib/matrix/eink/stock_chart.rs
@@ -27,6 +27,7 @@
 use crate::api::stock::model::{HistorySeries, StockHistory};
 use crate::matrix::eink::layout::{
     badge, badge_width, footer, header_band, margin, right_text, scaled_px, sparkline,
+    sparkline_timed,
 };
 use crate::matrix::eink_renderer::EinkRenderer;
 use crate::matrix::error::RenderError;
@@ -124,7 +125,21 @@ impl EinkStockChartMatrix {
                 let hl_w = self.pct.text_width(&format!("{:.0}", series.high)).max(self.pct.text_width(&format!("{:.0}", series.low)));
                 let plot_w = wi - m - plot_x - hl_w - m / 2;
                 let pts: Vec<f32> = series.closes.iter().map(|&v| v as f32).collect();
-                sparkline(&mut img, plot_x, plot_y, plot_w, plot_h, &pts, fg);
+                // The 1D row anchors x to the trading session (time of
+                // day) when the provider supplied intraday timestamps; a
+                // day in progress fills only the elapsed portion. Other
+                // rows (and crypto) keep even index spacing.
+                match series.intraday() {
+                    Some((_, times, sess)) if sess.end > sess.start => {
+                        let span = (sess.end - sess.start) as f32;
+                        let fracs: Vec<f32> = times
+                            .iter()
+                            .map(|&t| ((t - sess.start) as f32 / span).clamp(0.0, 1.0))
+                            .collect();
+                        sparkline_timed(&mut img, plot_x, plot_y, plot_w, plot_h, &pts, &fracs, fg);
+                    }
+                    _ => sparkline(&mut img, plot_x, plot_y, plot_w, plot_h, &pts, fg),
+                }
                 // High at the top-right, low at the bottom-right of the plot.
                 right_text(&mut img, &self.pct, wi - m, plot_y + self.pct.ascent(), fg, &format!("{:.0}", series.high));
                 right_text(&mut img, &self.pct, wi - m, plot_y + plot_h - self.pct.height() + self.pct.ascent(), fg, &format!("{:.0}", series.low));
@@ -170,6 +185,16 @@ mod tests {
         HistorySeries::from_closes((0..n).map(|i| base + i as f64 * slope).collect())
     }
 
+    fn intraday_series(n: usize, base: f64, slope: f64, fill_frac: f64) -> HistorySeries {
+        use crate::api::stock::model::TradingSession;
+        let closes: Vec<f64> = (0..n).map(|i| base + i as f64 * slope).collect();
+        let session = TradingSession { start: 0, end: 23_400 };
+        let times: Vec<i64> = (0..n)
+            .map(|i| (i as f64 / (n.max(2) - 1) as f64 * 23_400.0 * fill_frac).round() as i64)
+            .collect();
+        HistorySeries::from_samples(closes, times, Some(session))
+    }
+
     fn sample() -> StockHistory {
         StockHistory {
             api: StockApiSource::Yahoo,
@@ -198,6 +223,37 @@ mod tests {
         s.day = HistorySeries::from_closes(vec![]);
         let img = r.frame(&s, 800, 480);
         assert!(img.pixels().filter(|p| p.0 != [0, 0, 0]).count() > 200, "empty window still renders");
+    }
+
+    #[test]
+    fn intraday_day_row_leaves_trailing_space() {
+        // A 1D row half-elapsed should draw its sparkline only across the
+        // left portion of the plot; the trailing time hasn't happened.
+        // Compare lit pixels in the right quarter of the plot band vs a
+        // full session — the partial day must light fewer.
+        let r = EinkStockChartMatrix::with_fonts(repo_fonts(), (800, 480)).unwrap();
+        let mut partial = sample();
+        partial.day = intraday_series(40, 188.0, 0.15, 0.5);
+        let mut full = sample();
+        full.day = intraday_series(40, 188.0, 0.15, 1.0);
+
+        // The two samples differ *only* in the 1D row's x-positions
+        // (closes, labels, footer, and the 1M/1Y rows are identical), so
+        // any difference in right-side ink is the intraday sparkline.
+        let right_quarter_ink = |img: &RgbImage| -> usize {
+            let w = img.width();
+            let h = img.height();
+            ((w * 3 / 4)..w)
+                .flat_map(|x| (0..h).map(move |y| (x, y)))
+                .filter(|&(x, y)| img.get_pixel(x, y).0 != [0, 0, 0])
+                .count()
+        };
+        let p = right_quarter_ink(&r.frame(&partial, 800, 480));
+        let f = right_quarter_ink(&r.frame(&full, 800, 480));
+        assert!(
+            p < f,
+            "partial-day 1D row should light fewer right-side pixels than a full session ({p} vs {f})"
+        );
     }
 
     #[test]

--- a/src/lib/matrix/stock_chart.rs
+++ b/src/lib/matrix/stock_chart.rs
@@ -23,14 +23,20 @@
 //!   read like a rolling caption while the dominant numbers stay
 //!   visible at rest.
 //! - **Graph (bottom 24 px)**: line drawn between consecutive closes.
-//!   The series is bucketed across the 62-px-wide plotting area so a
-//!   ~78-sample intraday window and a ~52-sample yearly window both
-//!   compress cleanly. Y-axis autoscales to that window's `low`/`high`
-//!   — a flat 1D doesn't get dwarfed by a volatile 1Y. Color follows
-//!   the window's own direction (`closes[0]` vs `closes[last]`).
-//! - **Current-price marker**: a 2 px triangle at the right edge of
-//!   the active window. Always white so the "where we are now" reads
-//!   independent of the line color.
+//!   Y-axis autoscales to that window's `low`/`high` — a flat 1D
+//!   doesn't get dwarfed by a volatile 1Y. Color follows the window's
+//!   own direction (`closes[0]` vs `closes[last]`). The x-axis depends
+//!   on the window:
+//!   - **1D (intraday)**: anchored to the regular trading session
+//!     (9:30 AM → 4:00 PM, from the provider's session bounds). Each
+//!     close lands at its real time of day, so a day still in progress
+//!     fills only the elapsed left portion and the rest stays blank.
+//!   - **1M / 1Y (and crypto)**: bucketed evenly across the 62-px
+//!     plotting area so the whole window always spans the graph.
+//! - **Current-price marker**: a 2 px triangle at the newest sample —
+//!   the right edge for completed/even-spaced windows, or wherever
+//!   "now" falls on the intraday time axis. Always white so the "where
+//!   we are now" reads independent of the line color.
 //! - **Period cycle**: 12 s render cycle ⇒ 4 s on each of 1D, 1M, 1Y,
 //!   then return. Empty windows render a "NO DATA" badge in their
 //!   slot instead of an empty graph.
@@ -295,9 +301,6 @@ impl StockChartMatrix {
             Direction::Flat => FLAT,
         };
 
-        let width_px = (GRAPH_RIGHT - GRAPH_LEFT + 1) as usize;
-        let buckets = bucket_to_width(&series.closes, width_px);
-
         // Vertical scaling: clamp degenerate ranges so a flat series
         // draws a horizontal stripe rather than dividing by zero.
         let mut lo = series.low;
@@ -313,6 +316,39 @@ impl StockChartMatrix {
             // Invert: higher price = smaller y (closer to top of graph).
             GRAPH_BOTTOM - (t * (GRAPH_BOTTOM - GRAPH_TOP) as f64).round() as i32
         };
+
+        // Intraday (1D) path: anchor x to the trading session so a
+        // half-finished day fills only the elapsed portion of the axis.
+        if let Some((closes, times, session)) = series.intraday() {
+            if session.end > session.start {
+                let span = (session.end - session.start) as f64;
+                let to_x = |ts: i64| -> i32 {
+                    let t = ((ts - session.start) as f64 / span).clamp(0.0, 1.0);
+                    GRAPH_LEFT + (t * (GRAPH_RIGHT - GRAPH_LEFT) as f64).round() as i32
+                };
+                let mut prev: Option<(i32, i32)> = None;
+                for (i, &price) in closes.iter().enumerate() {
+                    let pt = (to_x(times[i]), to_y(price));
+                    if let Some((px, py)) = prev {
+                        draw_line(img, px, py, pt.0, pt.1, color);
+                    }
+                    prev = Some(pt);
+                }
+                // Marker rides the newest sample — wherever "now" sits on
+                // the time axis, not pinned to the right edge.
+                if let Some((mx, my)) = prev {
+                    put(img, mx, my, MARKER);
+                    put(img, mx - 1, my, MARKER);
+                    put(img, mx, my - 1, MARKER);
+                }
+                return;
+            }
+        }
+
+        // Even-spacing path (1M / 1Y / crypto): bucket across the full
+        // width so the whole window always spans the graph.
+        let width_px = (GRAPH_RIGHT - GRAPH_LEFT + 1) as usize;
+        let buckets = bucket_to_width(&series.closes, width_px);
 
         // Draw connected segments. With buckets.len() == width_px,
         // each segment is one pixel wide.
@@ -530,7 +566,7 @@ fn put(img: &mut RgbImage, x: i32, y: i32, c: Color) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::stock::model::StockApiSource;
+    use crate::api::stock::model::{StockApiSource, TradingSession};
     use std::path::PathBuf;
 
     fn repo_fonts() -> StockChartFonts {
@@ -554,6 +590,67 @@ mod tests {
             month,
             year,
         }
+    }
+
+    /// Build an intraday day series whose samples span `fill_frac` of
+    /// the `[start, end]` session — `fill_frac < 1.0` models a trading
+    /// day still in progress.
+    fn intraday(closes: Vec<f64>, start: i64, end: i64, fill_frac: f64) -> HistorySeries {
+        let n = closes.len().max(2);
+        let span = (end - start) as f64;
+        let times: Vec<i64> = (0..closes.len())
+            .map(|i| start + (i as f64 / (n - 1) as f64 * span * fill_frac).round() as i64)
+            .collect();
+        HistorySeries::from_samples(closes, times, Some(TradingSession { start, end }))
+    }
+
+    /// Count non-black graph-area pixels in the column range `xs`.
+    fn graph_lit_in_cols(img: &RgbImage, xs: std::ops::Range<u32>) -> usize {
+        xs.flat_map(|x| (GRAPH_TOP as u32..=GRAPH_BOTTOM as u32).map(move |y| (x, y)))
+            .filter(|&(x, y)| img.get_pixel(x, y).0 != [0, 0, 0])
+            .count()
+    }
+
+    #[test]
+    fn intraday_half_day_leaves_right_half_empty() {
+        // A session half-elapsed should draw a line only across the left
+        // ~half of the graph; the trailing time hasn't happened yet.
+        let m = StockChartMatrix::with_fonts(repo_fonts()).expect("fonts");
+        let day = intraday((0..40).map(|i| 180.0 + i as f64 * 0.05).collect(), 0, 23_400, 0.5);
+        let h = sample(day, ramp(170.0, 0.5, 22), ramp(140.0, 0.8, 52));
+        let img = m.draw_frame(&h, Period::Day, 0);
+        let left = graph_lit_in_cols(&img, (GRAPH_LEFT as u32)..32);
+        let right = graph_lit_in_cols(&img, 40..(GRAPH_RIGHT as u32 + 1));
+        assert!(left > 10, "left half should carry the line, got {left}");
+        assert_eq!(right, 0, "right half (future time) must stay empty, got {right}");
+    }
+
+    #[test]
+    fn intraday_full_session_spans_the_width() {
+        // A completed session reaches the right edge — the marker sits at
+        // GRAPH_RIGHT just like the bucketed windows.
+        let m = StockChartMatrix::with_fonts(repo_fonts()).expect("fonts");
+        let day = intraday((0..78).map(|i| 180.0 + i as f64 * 0.05).collect(), 0, 23_400, 1.0);
+        let h = sample(day, ramp(170.0, 0.5, 22), ramp(140.0, 0.8, 52));
+        let img = m.draw_frame(&h, Period::Day, 0);
+        // The right-edge column should be lit (marker + line tail).
+        let right_edge = graph_lit_in_cols(&img, (GRAPH_RIGHT as u32)..(GRAPH_RIGHT as u32 + 1));
+        assert!(right_edge > 0, "full session should reach the right edge");
+    }
+
+    #[test]
+    fn month_window_ignores_intraday_and_fills_width() {
+        // The month series has no timestamps → even-spacing path → line
+        // spans the whole width regardless of time of day.
+        let m = StockChartMatrix::with_fonts(repo_fonts()).expect("fonts");
+        let h = sample(
+            intraday((0..40).map(|i| 180.0 + i as f64 * 0.05).collect(), 0, 23_400, 0.5),
+            ramp(170.0, 0.5, 22),
+            ramp(140.0, 0.8, 52),
+        );
+        let img = m.draw_frame(&h, Period::Month, 0);
+        let right = graph_lit_in_cols(&img, 40..(GRAPH_RIGHT as u32 + 1));
+        assert!(right > 5, "month window should fill the full width, got {right}");
     }
 
     #[test]

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -53,7 +53,7 @@ use oledlib::matrix::launch::{LaunchFonts, LaunchMatrix};
 use oledlib::matrix::pihole::{PiholeFonts, PiholeMatrix};
 use oledlib::matrix::quake::{QuakeFonts, QuakeMatrix};
 use oledlib::matrix::sport::{SportFonts, SportMatrix};
-use oledlib::api::stock::{HistorySeries, StockHistory};
+use oledlib::api::stock::{HistorySeries, StockHistory, TradingSession};
 use oledlib::matrix::stock::{StockFonts, StockMatrix};
 use oledlib::matrix::stock_chart::{StockChartFonts, StockChartMatrix};
 use oledlib::matrix::time::TimeSnapshot;
@@ -444,7 +444,9 @@ async fn preview_eink_stock_chart(display: &mut EinkDisplay, fonts: &Path) -> Re
         symbol: "AAPL".into(),
         current: 191.2,
         previous_close: 190.0,
-        day: series(24, 188.0, 0.2),
+        // ~70% through the trading day so the 1D row's time-anchored
+        // x-axis shows blank trailing space.
+        day: intraday_day(series(24, 188.0, 0.2).closes, 0.70),
         month: series(30, 180.0, 0.5),
         year: series(52, 150.0, 0.9),
     };
@@ -617,6 +619,19 @@ async fn preview_stock(matrix: &mut RGBMatrix, fonts: &Path) -> Result<(), Strin
     }
 }
 
+/// Build a 1D `HistorySeries` whose samples span `fill_frac` of a
+/// 9:30→4:00 (6.5 h) session — `fill_frac < 1.0` models a trading day
+/// still in progress so the chart's time-anchored x-axis is visible.
+fn intraday_day(closes: Vec<f64>, fill_frac: f64) -> HistorySeries {
+    const SESSION_SECS: f64 = 23_400.0; // 6.5 h
+    let session = TradingSession { start: 0, end: SESSION_SECS as i64 };
+    let n = closes.len().max(2);
+    let times: Vec<i64> = (0..closes.len())
+        .map(|i| (i as f64 / (n - 1) as f64 * SESSION_SECS * fill_frac).round() as i64)
+        .collect();
+    HistorySeries::from_samples(closes, times, Some(session))
+}
+
 async fn preview_stock_chart(matrix: &mut RGBMatrix, fonts: &Path) -> Result<(), String> {
     let mut r = StockChartMatrix::with_fonts_async(StockChartFonts {
         body: fonts.join("04B_03B_.TTF"),
@@ -626,7 +641,10 @@ async fn preview_stock_chart(matrix: &mut RGBMatrix, fonts: &Path) -> Result<(),
     // 1D = noisy intraday wave that closes up; 1M = clear uptrend
     // with a midmonth dip; 1Y = steady climb. Lets the preview verify
     // the autoscale and direction-color logic across all three.
-    let day: Vec<f64> = (0..78)
+    // 1D is a trading day ~70% elapsed: the line fills the left ~70% of
+    // the axis (9:30 → ~2:00 PM) and the rest stays blank, exercising the
+    // time-anchored intraday path. 1M/1Y keep even index spacing.
+    let day: Vec<f64> = (0..55)
         .map(|i| 180.0 + (i as f64 * 0.12).sin() * 1.2 + i as f64 * 0.03)
         .collect();
     let month: Vec<f64> = (0..22)
@@ -640,7 +658,7 @@ async fn preview_stock_chart(matrix: &mut RGBMatrix, fonts: &Path) -> Result<(),
         symbol: "AAPL".into(),
         current: *day.last().unwrap(),
         previous_close: day[0],
-        day: HistorySeries::from_closes(day),
+        day: intraday_day(day, 0.70),
         month: HistorySeries::from_closes(month),
         year: HistorySeries::from_closes(year),
     };


### PR DESCRIPTION
## Summary

The stock chart's **1D window** now plots each close at its **real time of day** across the regular trading session (9:30 AM → 4:00 PM ET). While the market is open, a day still in progress fills only the elapsed left portion of the axis and the rest stays blank — instead of stretching the partial day across the full width. The 1M / 1Y windows (and crypto) keep their even index-spacing.

The axis end uses the provider's reported regular-session close (4:00 PM), not a fixed 4:30.

## Changes

**Data model** (`api/stock/model.rs`)
- New `TradingSession { start, end }` (epoch seconds).
- `HistorySeries` gains `times: Vec<i64>` (parallel to `closes`) and `session: Option<TradingSession>`, plus `from_samples(...)` (lockstep NaN/timestamp filtering) and an `intraday()` accessor. `from_closes` still drives the even-spacing windows.

**Yahoo provider** (`api/stock/yahoo.rs`)
- Captures the `timestamp[]` array aligned with closes (a dropped null close drops its timestamp too).
- Derives the session from `meta.gmtoffset` + `currentTradingPeriod.regular`, taking only the session's **time-of-day** and re-anchoring it to the calendar day of the actual bars. Robust to Yahoo rolling `currentTradingPeriod` forward after close (which would otherwise collapse the line to the left edge), and DST / non-US-exchange correct without a timezone database.

**Renderers**
- `matrix/stock_chart.rs`: `draw_graph` branches — intraday path positions each point by `(ts - start)/(end - start)`, marker rides the newest sample; falls back to bucketing otherwise.
- `eink/stock_chart.rs` + `eink/layout.rs`: new `sparkline_timed` helper; the e-ink 1D row uses it for parity.

**Previews**: both chart previews now show a ~70%-elapsed day so the trailing blank space is visible.

## Tests

New coverage for lockstep timestamp filtering, session derivation (incl. the after-hours roll-forward case), intraday half-day-leaves-right-empty, full-session spanning, and non-1D windows ignoring time anchoring.

All 350 lib tests + doc tests pass; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)