### PR TITLE
Release: sleep mode, e-ink/sport fixes, intraday stock chart

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -547,6 +547,7 @@ scheduler.
 | Add a new font                        | `src/sh/install.sh` + the renderer's `*Fonts` struct                   |
 | Change a shared HTTP behavior         | `src/lib/api/http.rs`                                                  |
 | Tweak the scheduler                   | `src/lib/modules/scheduler.rs`                                         |
+| Change sleep-mode behavior            | `src/lib/modules/sleep.rs` (gate + `SleepSchedule`); `SleepConfig` is a **top-level** block in `registry.rs`, parsed in `main.rs` (`SleepTopConfig`), gated in `scheduler.rs` (render loops) + `mod.rs` (`background_poll`) |
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "ohmyoled"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,8 +389,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -526,6 +528,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "croner"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aa42bcd3d846ebf66e15bd528d1087f75d1c6c1c66ebff626178a106353c576"
+dependencies = [
+ "chrono",
+ "derive_builder",
+ "strum 0.27.2",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,12 +618,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -628,11 +665,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -650,6 +698,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1408,7 +1487,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "indoc",
  "proc-macro2",
  "quote",
@@ -1851,6 +1930,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "clap",
+ "croner",
  "env_logger",
  "image",
  "libc",
@@ -2287,7 +2367,7 @@ dependencies = [
  "lru",
  "palette",
  "serde",
- "strum",
+ "strum 0.28.0",
  "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
@@ -2340,7 +2420,7 @@ dependencies = [
  "line-clipping",
  "ratatui-core",
  "serde",
- "strum",
+ "strum 0.28.0",
  "time",
  "unicode-segmentation",
  "unicode-width",
@@ -2861,11 +2941,32 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.28.0",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "ohmyoled"
-version = "4.0.0"
+version = "4.1.0"
 edition = "2021"
 default-run = "ohmyoled"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,9 @@ async-trait = "0.1"
 ratatui = "0.30"
 tui-input = "0.15"
 sunrise = { version = "3", features = ["std"] }
+# Standard crontab parsing for the optional `sleep` schedule. Works directly on
+# chrono `DateTime`, so it slots into the existing Local::now() time handling.
+croner = "3"
 ohmyoled-matrix = { path = "crates/ohmyoled-matrix", default-features = false }
 
 [features]

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ backstory.
   - [`launch`](#launch)
   - [`hass`](#hass)
   - [`pihole`](#pihole)
+  - [`sleep`](#sleep)
 - [Environment variables](#environment-variables)
 - [Fonts](#fonts)
 - [Gotchas](#gotchas)
@@ -581,6 +582,48 @@ Refresh: 30 s. Data source: Pi-hole v5 `admin/api.php?summaryRaw`
 endpoint. The Pi-hole v6 API moves auth to a session-token model and
 isn't implemented yet — the `PiholeSource` enum has a slot for it
 when the v6 ergonomics settle.
+
+---
+
+### `sleep`
+
+A schedule-driven **sleep mode**. When `enabled: true`, the daemon **blanks
+both panels** (LED matrix and e-paper) and **pauses all API polling** while the
+schedule says it's asleep — useful overnight to save the panel and your API
+quotas. It's purely schedule-driven (no manual toggle), so it behaves the same
+in a Docker container as on bare metal.
+
+Three schedule shapes are supported and **OR'd together** — it's asleep if
+**any** of them matches. All times are evaluated against the **system local
+clock**, so mount `/etc/localtime` (or set `TZ`) in Docker to match your wall
+time.
+
+```yaml
+sleep:
+  enabled: true
+  # 1. Cron pair — enter sleep / wake at these instants (handles overnight).
+  sleep: "0 22 * * *"     # 10:00 PM → panels off
+  wake:  "0 7 * * *"      # 7:00 AM  → back on
+  # 2. Plain HH:MM window (wraps past midnight when start > end).
+  start: null
+  end:   null
+  # 3. Cron-anchored windows — asleep for `for_mins` after each firing.
+  windows:
+    - { at: "0 13 * * 6,0", for_mins: 120 }   # 2 h nap at 1 PM on weekends
+```
+
+| Field     | Type            | Required | Notes                                                                                  |
+| --------- | --------------- | -------- | -------------------------------------------------------------------------------------- |
+| `enabled` | bool            | yes      | Master switch. Omitted/false leaves every existing config unchanged.                   |
+| `sleep`   | string (cron)   | no       | 5-field crontab marking when to enter sleep. Must be paired with `wake`.               |
+| `wake`    | string (cron)   | no       | 5-field crontab marking when to wake. Must be paired with `sleep`.                      |
+| `start`   | string (`HH:MM`)| no       | Clock window start. Must be paired with `end`; wraps midnight when `start > end`.       |
+| `end`     | string (`HH:MM`)| no       | Clock window end (exclusive).                                                           |
+| `windows` | array           | no       | Each `{ at: <cron>, for_mins: <int> }` keeps the panels off for `for_mins` after `at`.  |
+
+A malformed cron / time string (or a half-configured pair) logs an error and
+leaves sleep mode disabled rather than failing startup. Evaluation re-runs every
+30 s, so transitions land within half a minute of the scheduled instant.
 
 ---
 

--- a/crates/ohmyoled-matrix/src/eink/hardware.rs
+++ b/crates/ohmyoled-matrix/src/eink/hardware.rs
@@ -65,6 +65,14 @@ const BUSY_TIMEOUT: Duration = Duration::from_secs(30);
 /// controller latches data across chunks, matching Waveshare's `send_data2`.
 const SPI_CHUNK: usize = 4096;
 
+/// How many fast/partial refreshes to allow before forcing a full-refresh
+/// deep-clean. Partial refreshes don't fully drive the pixels, so charge and
+/// ghosting accumulate; routing every Nth tile update through a full refresh
+/// resets the panel so the image never fades. Counted across tile changes (the
+/// per-second clock tick increments it but never triggers the clean mid-dwell,
+/// so a ticking tile doesn't flash).
+const FULL_REFRESH_EVERY: u32 = 12;
+
 /// No-op chip-select for `embedded-hal-bus`: `rppal` drives the real `CE0`
 /// line per transfer, so the `SpiDevice` abstraction's CS toggling is inert.
 struct NoCs;
@@ -90,10 +98,12 @@ type EpdSpi = ExclusiveDevice<Spi, NoCs, Delay>;
 /// vs data (high).
 ///
 /// Updates use the panel's **fast/partial** refresh ([`init_part`] +
-/// [`display_partial`]) so screen changes are quick and never do the slow,
-/// flashy full-screen refresh. Each [`update`] clears to white then draws the
-/// new frame — both partial refreshes — so the previous frame's ghost is
-/// scrubbed without a full refresh.
+/// [`display_partial`]) so screen changes are quick. Each [`update`] clears to
+/// white then draws the new frame — both partial refreshes — so the previous
+/// frame's ghost is scrubbed. Partial refreshes don't fully drive the pixels,
+/// though, so every [`FULL_REFRESH_EVERY`] updates one is promoted to a full
+/// refresh ([`update_full`]) to reset accumulated ghosting before it fades the
+/// image.
 struct SevenIn5V2 {
     spi: Spi,
     rst: Out,
@@ -102,6 +112,10 @@ struct SevenIn5V2 {
     /// Whether the controller is currently in partial-update mode (`init_part`).
     /// [`clear`] re-enters full mode, so the next update re-arms partial mode.
     in_partial_mode: bool,
+    /// Fast/partial refreshes since the last full refresh. Drives the periodic
+    /// [`FULL_REFRESH_EVERY`] deep-clean so accumulated ghosting never fades the
+    /// image. Reset by any full refresh ([`update_full`]/[`clear`]).
+    partial_since_full: u32,
 }
 
 impl SevenIn5V2 {
@@ -117,6 +131,7 @@ impl SevenIn5V2 {
             dc,
             busy,
             in_partial_mode: false,
+            partial_since_full: 0,
         };
         // Full power-on setup (resolution, VCOM, TCON). Updates then switch to
         // partial mode; the first update's clear scrubs any retained image.
@@ -261,6 +276,12 @@ impl SevenIn5V2 {
     /// refreshes. The white clear scrubs the previous frame's ghost without the
     /// slow full-screen refresh.
     fn update(&mut self, packed: &[u8]) -> Result<(), String> {
+        // Periodic deep-clean: partial refreshes accumulate ghosting and fade,
+        // so every FULL_REFRESH_EVERY tile updates we route through a full
+        // refresh (which resets the counter) instead of the fast partial path.
+        if self.partial_since_full >= FULL_REFRESH_EVERY {
+            return self.update_full(packed);
+        }
         if !self.in_partial_mode {
             self.init_part()?;
             self.in_partial_mode = true;
@@ -268,6 +289,7 @@ impl SevenIn5V2 {
         let white = vec![0xFF; Self::FRAME_BYTES];
         self.display_partial(&white)?;
         self.display_partial(packed)?;
+        self.partial_since_full += 1;
         Ok(())
     }
 
@@ -280,6 +302,11 @@ impl SevenIn5V2 {
             self.init_part()?;
             self.in_partial_mode = true;
         }
+        // Count toward the deep-clean budget but never trigger it here: a
+        // ticking tile (clock, countdown) calls this every second and must not
+        // flash a full refresh mid-dwell. The accumulated count is paid off by
+        // the next per-tile `update`, which de-ghosts the ticking tile's trail.
+        self.partial_since_full = self.partial_since_full.saturating_add(1);
         self.display_partial(packed)
     }
 
@@ -292,7 +319,15 @@ impl SevenIn5V2 {
             self.init()?;
             self.in_partial_mode = false;
         }
-        self.display_full(packed)
+        // Clear to white first so the fine stipple develops on a clean substrate
+        // — a single transition pass can leave residual ghosting on detail-dense
+        // frames, which is exactly where the fade shows worst (the world maps).
+        let white = vec![0xFF; Self::FRAME_BYTES];
+        self.display_full(&white)?;
+        self.display_full(packed)?;
+        // A full refresh resets the panel; the ghosting budget starts over.
+        self.partial_since_full = 0;
+        Ok(())
     }
 
     /// Blank the panel to white with a clean full refresh. Restores full mode
@@ -302,6 +337,7 @@ impl SevenIn5V2 {
     fn clear(&mut self) -> Result<(), String> {
         self.init()?;
         self.in_partial_mode = false;
+        self.partial_since_full = 0;
         let white = vec![0xFF; Self::FRAME_BYTES];
         self.display_full(&white)
     }

--- a/examples/config_formats.rs
+++ b/examples/config_formats.rs
@@ -4,7 +4,7 @@
 //! `examples/configs/ohmyoled.{json,yaml,toml}`, deserializes each into
 //! `RegistryConfig`, and prints a short summary.
 
-use oledlib::modules::registry::{EinkRegistryConfig, RegistryConfig, SportSection};
+use oledlib::modules::registry::{EinkRegistryConfig, RegistryConfig, SleepConfig, SportSection};
 use std::path::PathBuf;
 
 /// Pulls the top-level `eink` block, mirroring how `main.rs` parses it.
@@ -12,6 +12,13 @@ use std::path::PathBuf;
 struct EinkTop {
     #[serde(default)]
     eink: EinkRegistryConfig,
+}
+
+/// Pulls the top-level `sleep` block, mirroring how `main.rs` parses it.
+#[derive(serde::Deserialize, Default)]
+struct SleepTop {
+    #[serde(default)]
+    sleep: SleepConfig,
 }
 
 fn fixture(name: &str) -> PathBuf {
@@ -101,4 +108,30 @@ fn main() {
     assert_eq!(sej, sey, "eink json/yaml diverge");
     assert_eq!(sej, set, "eink json/toml diverge");
     println!("all three formats produce equivalent eink config");
+
+    // The independent `sleep` block must also parse equivalently in all three.
+    let json_v2 = load_as_json_value(&fixture("ohmyoled.json"));
+    let yaml_v2 = load_as_json_value(&fixture("ohmyoled.yaml"));
+    let toml_v2 = load_as_json_value(&fixture("ohmyoled.toml"));
+    let zj: SleepTop = serde_json::from_value(json_v2).expect("json -> SleepTop");
+    let zy: SleepTop = serde_json::from_value(yaml_v2).expect("yaml -> SleepTop");
+    let zt: SleepTop = serde_json::from_value(toml_v2).expect("toml -> SleepTop");
+    let sleep_summary = |s: &SleepTop| {
+        format!(
+            "enabled={} sleep={:?} wake={:?} start={:?} end={:?} windows={}",
+            s.sleep.enabled,
+            s.sleep.sleep,
+            s.sleep.wake,
+            s.sleep.start,
+            s.sleep.end,
+            s.sleep.windows.len()
+        )
+    };
+    let (szj, szy, szt) = (sleep_summary(&zj), sleep_summary(&zy), sleep_summary(&zt));
+    println!("sleep json: {szj}");
+    println!("sleep yaml: {szy}");
+    println!("sleep toml: {szt}");
+    assert_eq!(szj, szy, "sleep json/yaml diverge");
+    assert_eq!(szj, szt, "sleep json/toml diverge");
+    println!("all three formats produce equivalent sleep config");
 }

--- a/examples/configs/ohmyoled-eink.yaml
+++ b/examples/configs/ohmyoled-eink.yaml
@@ -11,6 +11,13 @@
 # need a key or a local service (hass, pihole, finnhub stock) are left
 # `run: false` with placeholders — flip them on and fill in the values.
 
+# Sleep mode (opt-in): blanks the panel and pauses all polling on a schedule.
+# Evaluated against system local time; the three shapes below are OR'd together.
+sleep:
+  enabled: false
+  sleep: "0 22 * * *"          # enter sleep at 10:00 PM …
+  wake: "0 7 * * *"            # … wake at 7:00 AM
+
 eink:
   enabled: true
   model: "7in5_v2"            # 800x480 7.5" — the recommended panel

--- a/examples/configs/ohmyoled.json
+++ b/examples/configs/ohmyoled.json
@@ -109,6 +109,14 @@
     { "run": true, "sport": "golf", "tour": "pga" },
     { "run": true, "sport": "f1" }
   ],
+  "sleep": {
+    "enabled": false,
+    "sleep": "0 22 * * *",
+    "wake": "0 7 * * *",
+    "start": "null",
+    "end": "null",
+    "windows": []
+  },
   "eink": {
     "enabled": false,
     "model": "7in5_v2",

--- a/examples/configs/ohmyoled.toml
+++ b/examples/configs/ohmyoled.toml
@@ -172,6 +172,19 @@ tour = "pga"                  # pga | lpga | champions | korn | liv
 run = true
 sport = "f1"
 
+# ── Sleep mode — schedule-driven, opt-in ────────────────────────────
+# When enabled, blanks BOTH panels and pauses ALL API polling while the
+# schedule says it's asleep. All three shapes below are OR'd together
+# (asleep if any matches) and evaluated against the system local clock.
+[sleep]
+enabled = false
+sleep = "0 22 * * *"          # cron pair: enter sleep at 10:00 PM …
+wake = "0 7 * * *"            # … and wake at 7:00 AM (handles overnight)
+start = "null"               # OR a plain HH:MM window (wraps past midnight)
+end = "null"
+windows = []                 # OR cron-anchored windows, e.g.
+                             # [{ at = "0 13 * * 6,0", for_mins = 120 }]
+
 # ── E-paper (e-ink) display — independent, opt-in ────────────────────
 # Drives a Waveshare B/W e-paper HAT instead of the LED matrix when
 # enabled. Same data collectors, but its own separately-tuned tile

--- a/examples/configs/ohmyoled.yaml
+++ b/examples/configs/ohmyoled.yaml
@@ -167,6 +167,18 @@ sport:
   - run: true
     sport: f1
 
+# ── Sleep mode — schedule-driven, opt-in ────────────────────────────
+# When enabled, blanks BOTH panels and pauses ALL API polling while the
+# schedule says it's asleep. All three shapes below are OR'd together
+# (asleep if any matches) and evaluated against the system local clock.
+sleep:
+  enabled: false
+  sleep: "0 22 * * *"          # cron pair: enter sleep at 10:00 PM …
+  wake: "0 7 * * *"            # … and wake at 7:00 AM (handles overnight)
+  start: "null"               # OR a plain HH:MM window (wraps past midnight)
+  end: "null"
+  windows: []                 # OR cron-anchored windows: [{ at: "0 13 * * 6,0", for_mins: 120 }]
+
 # ── E-paper (e-ink) display — independent, opt-in ────────────────────
 # Drives a Waveshare B/W e-paper HAT instead of the LED matrix when
 # enabled. Same data collectors, but its own separately-tuned tile

--- a/examples/sport_render_check.rs
+++ b/examples/sport_render_check.rs
@@ -53,6 +53,7 @@ fn main() {
                 score: Some(100),
             },
             our_side: HomeOrAway::Home,
+            playoff_note: None,
         }),
         standings: (1..=5)
             .map(|i| StandingsEntry {

--- a/src/createjson/mod.rs
+++ b/src/createjson/mod.rs
@@ -73,6 +73,7 @@ pub fn default_config() -> Value {
         "launch": {"run":false,"agency_filter":[],"cache_ttl_secs":null},
         "hass": {"run":false,"base_url":"http://homeassistant.local:8123","token":"REPLACE_ME_HASS_LONG_LIVED_TOKEN","entity_id":"sensor.kitchen_temp","label":"null","alarm_state":"null","nominal_color":[120,220,120],"alarm_color":[255,60,60],"display_mode":"state","cache_ttl_secs":null},
         "pihole": {"run":false,"base_url":"http://pi.hole","token":"null","cache_ttl_secs":null},
+        "sleep": {"enabled":false,"sleep":"null","wake":"null","start":"null","end":"null","windows":[]},
         "eink": {"enabled":false,"model":"7in5_v2","rotation":0,"threshold":128,"mode":"auto","emulate":false,"refresh_ms":2500,"modules":{"time":{"run":true,"color":[255,255,255],"time_format":"12h","timezone":"null","cache_ttl_secs":null},"weather":{"run":false,"api":"nws","current_location":true,"current_location_api_key":"REPLACE_ME_IPINFO_TOKEN","weather_format":"imperial","animation":"subtle","cache_ttl_secs":null}}}
     }"#;
     serde_json::from_str(json).expect("starter config must parse")
@@ -102,6 +103,7 @@ pub fn create_json(
                 {"run":true,"sport":"golf","tour":"pga"},
                 {"run":true,"sport":"f1"}
             ],
+            "sleep": {"enabled":false,"sleep":"null","wake":"null","start":"null","end":"null","windows":[]},
             "eink": {"enabled":false,"model":"7in5_v2","rotation":0,"threshold":128,"mode":"auto","emulate":false,"refresh_ms":2500,"modules":{"time":{"run":true,"color":[255,255,255],"time_format":"12h","timezone":"null"},"weather":{"run":true,"api":"nws","current_location":true,"current_location_api_key":"null","weather_format":"imperial","animation":"subtle"}}}
         }"#;
         return (

--- a/src/createjson/tui/app.rs
+++ b/src/createjson/tui/app.rs
@@ -105,6 +105,10 @@ pub struct App {
     pub should_quit: bool,
     /// `Some` on save (config + chosen format), `None` while running / on quit.
     pub result: Option<(Value, ConfigFormat)>,
+    /// Top-level `sleep` block carried over from a loaded config. The wizard
+    /// doesn't edit sleep mode, but it must not drop it on re-save — so it's
+    /// stashed here and re-emitted verbatim by [`super::preview::build_value`].
+    pub preserved_sleep: Option<Value>,
 }
 
 impl App {
@@ -123,6 +127,7 @@ impl App {
             .map(|v| load_instances(v, target))
             .unwrap_or_default();
         let fmt = initial_fmt.unwrap_or(ConfigFormat::Json);
+        let preserved_sleep = existing.as_ref().and_then(|v| v.get("sleep").cloned());
         let (screen, status) = if existing.is_some() {
             (
                 Screen::Modules,
@@ -149,6 +154,7 @@ impl App {
             status,
             should_quit: false,
             result: None,
+            preserved_sleep,
         }
     }
 

--- a/src/createjson/tui/preview.rs
+++ b/src/createjson/tui/preview.rs
@@ -49,6 +49,7 @@ fn build_matrix(app: &App, strict: bool, errs: &mut Vec<(String, String)>) -> Va
             map.insert(key.to_string(), v);
         }
     }
+    preserve_sleep(app, &mut map);
     Value::Object(map)
 }
 
@@ -68,7 +69,18 @@ fn build_eink(app: &App, strict: bool, errs: &mut Vec<(String, String)>) -> Valu
     block.insert("modules".to_string(), Value::Object(modules));
     let mut root = Map::new();
     root.insert("eink".to_string(), Value::Object(block));
+    preserve_sleep(app, &mut root);
     Value::Object(root)
+}
+
+/// Re-emit a `sleep` block carried over from a loaded config. The wizard never
+/// edits sleep mode, so this just keeps it from being silently dropped on save
+/// (works for either target, since `sleep` is a top-level, target-independent
+/// block).
+fn preserve_sleep(app: &App, map: &mut Map<String, Value>) {
+    if let Some(sleep) = &app.preserved_sleep {
+        map.insert("sleep".to_string(), sleep.clone());
+    }
 }
 
 /// Serialize the active target form (matrix options or eink-block scalars).
@@ -230,6 +242,28 @@ mod tests {
             assert!(stock.is_array(), "two stocks should be an array on {target:?}");
             assert_eq!(stock.as_array().unwrap().len(), 2);
         }
+    }
+
+    #[test]
+    fn preserves_loaded_sleep_block_on_both_targets() {
+        let cfg = json!({
+            "matrix_options": {"chain_length": 1},
+            "time": {"run": true, "color": [255, 255, 255]},
+            "sleep": {"enabled": true, "sleep": "0 22 * * *", "wake": "0 7 * * *"}
+        });
+        // Matrix target round-trips the sleep block verbatim.
+        let app = App::new(Some(cfg.clone()), None);
+        let v = preview_value(&app);
+        assert_eq!(v["sleep"], cfg["sleep"]);
+
+        // And an eink config keeps it too (top-level, target-independent).
+        let eink_cfg = json!({
+            "eink": {"enabled": true, "model": "7in5_v2", "modules": {"time": {"run": true}}},
+            "sleep": {"enabled": true, "start": "22:00", "end": "07:00"}
+        });
+        let app = App::new(Some(eink_cfg.clone()), None);
+        let v = preview_value(&app);
+        assert_eq!(v["sleep"], eink_cfg["sleep"]);
     }
 
     #[test]

--- a/src/lib/api/f1/mod.rs
+++ b/src/lib/api/f1/mod.rs
@@ -37,12 +37,32 @@ pub struct F1Data {
     pub standings: Vec<DriverStanding>,
 }
 
+/// Furthest out a `next_race` can be and still count as the *current* upcoming
+/// race. The longest in-season gap (the summer break) is ~4 weeks; between
+/// seasons jolpica's `/next` points at the new season's opener months out, which
+/// this excludes so the winter break reads as off-season (champion banner) and
+/// the countdown doesn't tick toward a race in March.
+const NEXT_RACE_HORIZON: chrono::Duration = chrono::Duration::days(45);
+
 impl F1Data {
-    /// `true` when there's no upcoming race scheduled. Standings may still be
-    /// populated (last season's table is what jolpica returns between
-    /// seasons), so the renderer uses that to show a champion banner.
+    /// The race to actually count down to, or `None` when the only race jolpica
+    /// gave us is next season's (months out → off-season). Renderers branch on
+    /// this rather than `next_race` directly.
+    pub fn current_race(&self, now: DateTime<Local>) -> Option<&NextRace> {
+        self.next_race.as_ref().filter(|r| r.start <= now + NEXT_RACE_HORIZON)
+    }
+
+    /// `true` when there's no *current* upcoming race. Standings may still be
+    /// populated (last season's table is what jolpica returns between seasons),
+    /// so the renderer uses that to show a champion banner. Evaluated against
+    /// `now` so a far-future winter-break race reads as off-season.
+    pub fn is_offseason_at(&self, now: DateTime<Local>) -> bool {
+        self.current_race(now).is_none()
+    }
+
+    /// Convenience wrapper over [`Self::is_offseason_at`] using the wall clock.
     pub fn is_offseason(&self) -> bool {
-        self.next_race.is_none()
+        self.is_offseason_at(Local::now())
     }
 }
 
@@ -90,5 +110,51 @@ impl Collector for F1Collector {
 
     async fn poll(&self) -> Result<F1Data, ApiError> {
         self.source.poll().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn race_at(start: DateTime<Local>) -> NextRace {
+        NextRace { round: 1, name: "GP".into(), circuit: "Track".into(), start }
+    }
+
+    #[test]
+    fn imminent_race_is_current() {
+        let now = Local::now();
+        let d = F1Data {
+            season: "2026".into(),
+            next_race: Some(race_at(now + chrono::Duration::days(7))),
+            standings: vec![],
+        };
+        assert!(d.current_race(now).is_some());
+        assert!(!d.is_offseason_at(now));
+    }
+
+    #[test]
+    fn summer_break_gap_still_counts_as_current() {
+        // The longest in-season gap is ~4 weeks — must NOT read as off-season.
+        let now = Local::now();
+        let d = F1Data {
+            season: "2026".into(),
+            next_race: Some(race_at(now + chrono::Duration::days(28))),
+            standings: vec![],
+        };
+        assert!(!d.is_offseason_at(now));
+    }
+
+    #[test]
+    fn next_season_opener_reads_as_offseason() {
+        // Winter break: jolpica points at March; months out → off-season.
+        let now = Local::now();
+        let d = F1Data {
+            season: "2026".into(),
+            next_race: Some(race_at(now + chrono::Duration::days(100))),
+            standings: vec![],
+        };
+        assert!(d.current_race(now).is_none());
+        assert!(d.is_offseason_at(now));
     }
 }

--- a/src/lib/api/sport/espn.rs
+++ b/src/lib/api/sport/espn.rs
@@ -191,6 +191,26 @@ struct Competition {
     status: Option<StatusWrapper>,
     #[serde(default)]
     competitors: Vec<Competitor>,
+    /// Playoff round/game headlines (e.g. "East 1st Round - Game 5"). Present
+    /// only in the postseason; empty otherwise.
+    #[serde(default)]
+    notes: Vec<CompetitionNote>,
+    /// Playoff series state, when this game is part of a series.
+    #[serde(default)]
+    series: Option<SeriesInfo>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CompetitionNote {
+    #[serde(default)]
+    headline: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct SeriesInfo {
+    /// e.g. "Series tied 2-2" / "BOS leads 3-2". ESPN names this `summary`.
+    #[serde(default)]
+    summary: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -345,7 +365,17 @@ fn normalize(
         } else {
             HomeOrAway::Away
         };
-        Some(NextGame { start, status, home, away, our_side })
+        // Postseason context: the round/game headline, plus the series score
+        // when present. Both are empty in the regular season → `None`.
+        let round = comp.notes.into_iter().map(|n| n.headline).find(|h| !h.is_empty());
+        let series = comp.series.map(|s| s.summary).filter(|s| !s.is_empty());
+        let playoff_note = match (round, series) {
+            (Some(r), Some(s)) => Some(format!("{r} · {s}")),
+            (Some(r), None) => Some(r),
+            (None, Some(s)) => Some(s),
+            (None, None) => None,
+        };
+        Some(NextGame { start, status, home, away, our_side, playoff_note })
     });
 
     let standings_entries = standings
@@ -464,6 +494,43 @@ mod tests {
         let json = r#"{"homeAway":"home","team":{"displayName":"X","abbreviation":"X"},"score":null}"#;
         let c: Competitor = serde_json::from_str(json).unwrap();
         assert_eq!(c.score.0, None);
+    }
+
+    #[test]
+    fn parses_playoff_round_and_series_note() {
+        // Postseason games carry a `notes` headline and a `series` block.
+        let team_json = r#"
+        {"team":{"displayName":"Boston Celtics","abbreviation":"BOS","record":{"items":[{"summary":"4-2"}]},
+          "nextEvent":[{
+            "date":"2026-05-12T23:30Z",
+            "competitions":[{
+              "status":{"type":{"state":"pre","completed":false,"description":"Scheduled"}},
+              "notes":[{"headline":"East Semifinals - Game 5"}],
+              "series":{"summary":"Series tied 2-2"},
+              "competitors":[
+                {"homeAway":"home","team":{"displayName":"Boston Celtics","abbreviation":"BOS"},"score":null},
+                {"homeAway":"away","team":{"displayName":"New York Knicks","abbreviation":"NYK"},"score":null}
+              ]
+            }]
+          }]
+        }}"#;
+        let team: TeamDetailResponse = serde_json::from_str(team_json).unwrap();
+        let standings: StandingsResponse = serde_json::from_str(r#"{"children":[]}"#).unwrap();
+        let d = normalize(SportKind::Basketball, "Boston Celtics", team, standings).unwrap();
+        let ng = d.next_game.expect("next_game");
+        assert_eq!(
+            ng.playoff_note.as_deref(),
+            Some("East Semifinals - Game 5 · Series tied 2-2")
+        );
+    }
+
+    #[test]
+    fn regular_season_game_has_no_playoff_note() {
+        // No `notes`/`series` → regular season → note stays None.
+        let team: TeamDetailResponse = serde_json::from_str(TEAM_FIXTURE).unwrap();
+        let standings: StandingsResponse = serde_json::from_str(STANDINGS_FIXTURE).unwrap();
+        let d = normalize(SportKind::Basketball, "Boston Celtics", team, standings).unwrap();
+        assert!(d.next_game.unwrap().playoff_note.is_none());
     }
 
     #[test]

--- a/src/lib/api/sport/model.rs
+++ b/src/lib/api/sport/model.rs
@@ -87,6 +87,39 @@ pub struct NextGame {
     pub away: TeamSide,
     /// Which side is *our* configured team.
     pub our_side: HomeOrAway,
+    /// Playoff context from ESPN — a round/game headline (e.g. "East
+    /// Semifinals Game 5") optionally followed by the series score ("Series
+    /// tied 2-2"). `None` for regular-season games, so renderers show it only
+    /// in the postseason.
+    pub playoff_note: Option<String>,
+}
+
+/// How long after a final whistle we keep showing the score before treating the
+/// slot as "no current game". Covers the gap between playoff series too.
+const RECENT_FINAL_GRACE: chrono::Duration = chrono::Duration::days(2);
+
+/// How far out a scheduled game can be and still count as the team's *current*
+/// next game. In-season the next game is always days away (bye weeks ≤ 14d);
+/// between seasons ESPN's `next_event` points months out, which this excludes.
+const UPCOMING_HORIZON: chrono::Duration = chrono::Duration::days(21);
+
+impl NextGame {
+    /// Whether this game is worth showing *now* as the team's current game.
+    ///
+    /// ESPN's team `next_event` doesn't go empty in the off-season — it keeps
+    /// returning the last final score (for weeks) or the first game of next
+    /// season (months out). Both render as a misleading "current" scoreboard, so
+    /// we treat a game as current only when it's actually live, imminent, or just
+    /// finished.
+    pub fn is_current(&self, now: DateTime<Local>) -> bool {
+        match self.status {
+            GameStatus::InProgress => true,
+            GameStatus::Scheduled => {
+                self.start <= now + UPCOMING_HORIZON && self.start >= now - RECENT_FINAL_GRACE
+            }
+            GameStatus::Final | GameStatus::Postponed => self.start >= now - RECENT_FINAL_GRACE,
+        }
+    }
 }
 
 /// One row in the league standings table.
@@ -109,10 +142,23 @@ pub struct SportData {
 }
 
 impl SportData {
-    /// `true` when there's no upcoming game and no standings to scroll — the
-    /// renderer falls back to a "{Sport} Offseason" placeholder.
+    /// The game to actually display, or `None` when the only game ESPN gave us
+    /// is stale (off-season). Renderers must branch on this rather than on
+    /// `next_game` directly so a weeks-old final score doesn't read as current.
+    pub fn current_game(&self, now: DateTime<Local>) -> Option<&NextGame> {
+        self.next_game.as_ref().filter(|g| g.is_current(now))
+    }
+
+    /// `true` when there's no *current* game and no standings to scroll — the
+    /// renderer falls back to a "{Sport} Offseason" placeholder. Evaluated
+    /// against `now` so a stale `next_event` from ESPN reads as off-season.
+    pub fn is_offseason_at(&self, now: DateTime<Local>) -> bool {
+        self.current_game(now).is_none() && self.standings.is_empty()
+    }
+
+    /// Convenience wrapper over [`Self::is_offseason_at`] using the wall clock.
     pub fn is_offseason(&self) -> bool {
-        self.next_game.is_none() && self.standings.is_empty()
+        self.is_offseason_at(Local::now())
     }
 }
 
@@ -140,5 +186,94 @@ mod tests {
             standings: vec![],
         };
         assert!(d.is_offseason());
+    }
+
+    fn side(name: &str) -> TeamSide {
+        TeamSide { name: name.into(), abbreviation: name.into(), logo_url: None, score: Some(0) }
+    }
+
+    fn game(start: DateTime<Local>, status: GameStatus) -> NextGame {
+        NextGame {
+            start,
+            status,
+            home: side("A"),
+            away: side("B"),
+            our_side: HomeOrAway::Home,
+            playoff_note: None,
+        }
+    }
+
+    fn data_with(game: Option<NextGame>, standings: bool) -> SportData {
+        SportData {
+            api: SportApiSource::Espn,
+            sport: SportKind::Basketball,
+            team_name: "A".into(),
+            record: "1-0".into(),
+            next_game: game,
+            standings: if standings {
+                vec![StandingsEntry { position: 1, team_name: "A".into() }]
+            } else {
+                vec![]
+            },
+        }
+    }
+
+    #[test]
+    fn in_progress_is_always_current() {
+        let now = Local::now();
+        // Even a weirdly-dated live game shows — the league is clearly active.
+        let g = game(now - chrono::Duration::days(40), GameStatus::InProgress);
+        assert!(g.is_current(now));
+    }
+
+    #[test]
+    fn imminent_scheduled_is_current_but_far_future_is_not() {
+        let now = Local::now();
+        assert!(game(now + chrono::Duration::days(3), GameStatus::Scheduled).is_current(now));
+        // Next season's opener months out — off-season, not a current game.
+        assert!(!game(now + chrono::Duration::days(90), GameStatus::Scheduled).is_current(now));
+    }
+
+    #[test]
+    fn recent_final_is_current_but_stale_final_is_not() {
+        let now = Local::now();
+        // Just-finished game: keep the score up briefly.
+        assert!(game(now - chrono::Duration::hours(6), GameStatus::Final).is_current(now));
+        // A weeks-old final is what ESPN serves all off-season — must read stale.
+        assert!(!game(now - chrono::Duration::days(20), GameStatus::Final).is_current(now));
+    }
+
+    #[test]
+    fn stale_final_reads_as_offseason() {
+        let now = Local::now();
+        let stale = game(now - chrono::Duration::days(30), GameStatus::Final);
+        let d = data_with(Some(stale), false);
+        // The bug: next_game is Some, but it's stale → no current game → off-season.
+        assert!(d.current_game(now).is_none());
+        assert!(d.is_offseason_at(now));
+    }
+
+    #[test]
+    fn playoff_series_active_keeps_showing_games() {
+        let now = Local::now();
+        // Mid-series: next game is a couple days out → current.
+        let g = game(now + chrono::Duration::days(2), GameStatus::Scheduled);
+        let d = data_with(Some(g), true);
+        assert!(d.current_game(now).is_some());
+        assert!(!d.is_offseason_at(now));
+    }
+
+    #[test]
+    fn knocked_out_team_falls_to_offseason_after_grace() {
+        let now = Local::now();
+        // Team lost its elimination game; ESPN serves only that final, no next.
+        // Within the grace window the final still shows…
+        let just_lost = game(now - chrono::Duration::hours(12), GameStatus::Final);
+        assert!(data_with(Some(just_lost), false).current_game(now).is_some());
+        // …but a few days after elimination there is no current game.
+        let eliminated = game(now - chrono::Duration::days(5), GameStatus::Final);
+        let d = data_with(Some(eliminated), false);
+        assert!(d.current_game(now).is_none());
+        assert!(d.is_offseason_at(now));
     }
 }

--- a/src/lib/api/stock/mod.rs
+++ b/src/lib/api/stock/mod.rs
@@ -12,7 +12,7 @@ pub mod finnhub;
 pub mod model;
 pub mod yahoo;
 
-pub use model::{Direction, HistorySeries, StockApiSource, StockHistory, StockQuote};
+pub use model::{Direction, HistorySeries, StockApiSource, StockHistory, StockQuote, TradingSession};
 
 use coingecko::{CoingeckoConfig, CoingeckoProvider};
 use finnhub::{FinnhubConfig, FinnhubProvider};

--- a/src/lib/api/stock/model.rs
+++ b/src/lib/api/stock/model.rs
@@ -62,6 +62,19 @@ pub enum Direction {
     Flat,
 }
 
+/// Regular trading session bounds (epoch seconds, UTC) for an
+/// intraday window. When present alongside per-sample `times`, the
+/// renderer anchors the x-axis to `[start, end]` and positions each
+/// sample by its real timestamp instead of evenly spacing them — so a
+/// half-finished trading day fills only the elapsed half of the axis.
+#[derive(Debug, Clone, Copy)]
+pub struct TradingSession {
+    /// Session open, epoch seconds (e.g. 9:30 AM ET).
+    pub start: i64,
+    /// Session close, epoch seconds (e.g. 4:00 PM ET).
+    pub end: i64,
+}
+
 /// One period's worth of historical closes, plus the precomputed
 /// extrema. The renderer needs the extrema for autoscaling the graph
 /// — keeping them on the series saves the renderer from re-scanning
@@ -74,28 +87,97 @@ pub struct HistorySeries {
     pub closes: Vec<f64>,
     pub low: f64,
     pub high: f64,
+    /// Epoch-second timestamp for each close, parallel to `closes`.
+    /// Empty unless the provider supplied intraday timestamps (only the
+    /// 1D equity window does today) — month/year and crypto leave this
+    /// empty and fall back to even spacing.
+    pub times: Vec<i64>,
+    /// Regular trading session bounds for this window, when known. Only
+    /// meaningful together with a fully-populated `times`.
+    pub session: Option<TradingSession>,
 }
 
 impl HistorySeries {
-    /// Compute the series from raw closes; min/max scan once at
-    /// construction time. Filters out NaN samples — some providers
-    /// pad missing intervals with nulls that deserialize into NaN.
-    pub fn from_closes(raw: Vec<f64>) -> Self {
-        let closes: Vec<f64> = raw.into_iter().filter(|v| v.is_finite()).collect();
-        let (low, high) = closes
+    /// Compute the extrema for a set of closes. An empty slice yields
+    /// `(0.0, 0.0)` so the renderer's autoscale never divides by ±inf.
+    fn extrema(closes: &[f64]) -> (f64, f64) {
+        if closes.is_empty() {
+            return (0.0, 0.0);
+        }
+        closes
             .iter()
             .copied()
             .fold((f64::INFINITY, f64::NEG_INFINITY), |(lo, hi), v| {
                 (lo.min(v), hi.max(v))
-            });
-        // An empty series yields ±inf extrema — collapse to (0, 0) so
-        // the renderer's autoscale doesn't divide by ±inf.
-        let (low, high) = if closes.is_empty() {
-            (0.0, 0.0)
+            })
+    }
+
+    /// Compute the series from raw closes; min/max scan once at
+    /// construction time. Filters out NaN samples — some providers
+    /// pad missing intervals with nulls that deserialize into NaN.
+    /// Leaves `times`/`session` empty: this is the even-spacing path
+    /// used by the month/year windows and by crypto.
+    pub fn from_closes(raw: Vec<f64>) -> Self {
+        let closes: Vec<f64> = raw.into_iter().filter(|v| v.is_finite()).collect();
+        let (low, high) = Self::extrema(&closes);
+        Self {
+            closes,
+            low,
+            high,
+            times: Vec::new(),
+            session: None,
+        }
+    }
+
+    /// Build an intraday series with per-sample timestamps and the
+    /// session bounds. Filters non-finite closes in lockstep with their
+    /// timestamps so the two arrays stay aligned. If `raw_times` doesn't
+    /// match `raw_closes` in length, the timestamps are dropped and the
+    /// series degrades gracefully to even spacing.
+    pub fn from_samples(
+        raw_closes: Vec<f64>,
+        raw_times: Vec<i64>,
+        session: Option<TradingSession>,
+    ) -> Self {
+        let have_times = raw_times.len() == raw_closes.len();
+        let mut closes = Vec::with_capacity(raw_closes.len());
+        let mut times = Vec::with_capacity(raw_closes.len());
+        for (i, v) in raw_closes.into_iter().enumerate() {
+            if v.is_finite() {
+                closes.push(v);
+                if have_times {
+                    times.push(raw_times[i]);
+                }
+            }
+        }
+        let (low, high) = Self::extrema(&closes);
+        // Only keep timestamps when they're fully aligned with closes.
+        let times = if times.len() == closes.len() {
+            times
         } else {
-            (low, high)
+            Vec::new()
         };
-        Self { closes, low, high }
+        Self {
+            closes,
+            low,
+            high,
+            times,
+            session,
+        }
+    }
+
+    /// Time-anchored view of the series: `(closes, times, session)` when
+    /// this window carries aligned per-sample timestamps and session
+    /// bounds. `None` for the even-spacing windows (month/year/crypto)
+    /// or any degenerate case, which tells the renderer to fall back to
+    /// bucketing across the full width.
+    pub fn intraday(&self) -> Option<(&[f64], &[i64], TradingSession)> {
+        let session = self.session?;
+        if self.closes.len() >= 2 && self.times.len() == self.closes.len() {
+            Some((&self.closes, &self.times, session))
+        } else {
+            None
+        }
     }
 
     pub fn is_empty(&self) -> bool {
@@ -221,6 +303,53 @@ mod tests {
         assert_eq!(s.high, 0.0);
         assert_eq!(s.direction(), Direction::Flat);
         assert_eq!(s.percent_change(), 0.0);
+    }
+
+    #[test]
+    fn from_samples_keeps_times_aligned_through_nan_filter() {
+        let session = TradingSession { start: 1_000, end: 24_400 };
+        let s = HistorySeries::from_samples(
+            vec![100.0, f64::NAN, 105.0, 95.0],
+            vec![1_000, 1_300, 1_600, 1_900],
+            Some(session),
+        );
+        // NaN sample dropped along with its timestamp.
+        assert_eq!(s.closes, vec![100.0, 105.0, 95.0]);
+        assert_eq!(s.times, vec![1_000, 1_600, 1_900]);
+        let (closes, times, sess) = s.intraday().expect("intraday view");
+        assert_eq!(closes.len(), times.len());
+        assert_eq!(sess.start, 1_000);
+    }
+
+    #[test]
+    fn from_samples_drops_times_on_length_mismatch() {
+        // A timestamp array that doesn't match closes is discarded — the
+        // series degrades to even spacing rather than mis-aligning.
+        let s = HistorySeries::from_samples(
+            vec![100.0, 105.0, 95.0],
+            vec![1_000, 1_300],
+            Some(TradingSession { start: 0, end: 1 }),
+        );
+        assert!(s.times.is_empty());
+        assert!(s.intraday().is_none());
+    }
+
+    #[test]
+    fn from_closes_has_no_intraday_view() {
+        let s = HistorySeries::from_closes(vec![100.0, 105.0, 95.0]);
+        assert!(s.times.is_empty());
+        assert!(s.session.is_none());
+        assert!(s.intraday().is_none());
+    }
+
+    #[test]
+    fn intraday_needs_two_samples() {
+        let s = HistorySeries::from_samples(
+            vec![100.0],
+            vec![1_000],
+            Some(TradingSession { start: 0, end: 1 }),
+        );
+        assert!(s.intraday().is_none(), "single sample can't draw a line");
     }
 
     #[test]

--- a/src/lib/api/stock/yahoo.rs
+++ b/src/lib/api/stock/yahoo.rs
@@ -15,7 +15,7 @@
 //! - The collector returns the last successfully populated snapshot;
 //!   poll failures log and skip rather than blanking the panel.
 
-use super::model::{HistorySeries, StockApiSource, StockHistory};
+use super::model::{HistorySeries, StockApiSource, StockHistory, TradingSession};
 use crate::api::error::ApiError;
 use crate::api::http::get_json;
 use serde::Deserialize;
@@ -77,7 +77,11 @@ impl YahooProvider {
             symbol: self.symbol.to_uppercase(),
             current,
             previous_close,
-            day: day.map(|p| HistorySeries::from_closes(p.closes)).unwrap_or_else(|_| HistorySeries::from_closes(vec![])),
+            // The 1D window carries per-sample timestamps + session
+            // bounds so the renderer can lay it out by time of day.
+            day: day
+                .map(|p| HistorySeries::from_samples(p.closes, p.times, p.session))
+                .unwrap_or_else(|_| HistorySeries::from_closes(vec![])),
             month: month
                 .map(|p| HistorySeries::from_closes(p.closes))
                 .unwrap_or_else(|_| HistorySeries::from_closes(vec![])),
@@ -107,31 +111,88 @@ impl YahooProvider {
 #[derive(Debug)]
 struct ParsedWindow {
     closes: Vec<f64>,
+    /// Epoch-second timestamp per surviving close, aligned with
+    /// `closes`. Empty when Yahoo omitted the `timestamp` array (it's
+    /// present on the intraday range, absent on some delisted symbols).
+    times: Vec<i64>,
+    /// Regular trading session for the day the bars belong to. `None`
+    /// when the meta block lacks the offset or trading-period fields.
+    session: Option<TradingSession>,
     last_close: f64,
     previous_close: Option<f64>,
 }
 
-/// Pure: pull the closes out of a parsed Yahoo response. Returns
-/// `None` if the chart block is empty or absent — Yahoo serves this
-/// shape for delisted/unknown symbols.
+/// Pure: pull the closes (and, when present, their timestamps) out of a
+/// parsed Yahoo response. Returns `None` if the chart block is empty or
+/// absent — Yahoo serves that shape for delisted/unknown symbols.
 fn parse_window(raw: RawResponse) -> Option<ParsedWindow> {
     let result = raw.chart.result.into_iter().next()?;
+    let timestamps = result.timestamp;
     let quote = result.indicators.quote.into_iter().next()?;
-    let closes: Vec<f64> = quote
-        .close
-        .into_iter()
-        .flatten() // drop null gaps
-        .filter(|v| v.is_finite())
-        .collect();
+
+    // Walk closes and timestamps together so dropping a null close also
+    // drops its timestamp — the two arrays must stay index-aligned.
+    let have_times = timestamps.len() == quote.close.len();
+    let mut closes = Vec::with_capacity(quote.close.len());
+    let mut times = Vec::with_capacity(quote.close.len());
+    for (i, c) in quote.close.into_iter().enumerate() {
+        if let Some(v) = c {
+            if v.is_finite() {
+                closes.push(v);
+                if have_times {
+                    times.push(timestamps[i]);
+                }
+            }
+        }
+    }
     if closes.is_empty() {
         return None;
     }
     let last_close = *closes.last().unwrap();
+
+    // Anchor the session to the calendar day of the most recent bar.
+    let session = times
+        .last()
+        .and_then(|&last_ts| session_for_day(&result.meta, last_ts));
+
     Some(ParsedWindow {
         closes,
+        times,
+        session,
         last_close,
         previous_close: result.meta.previous_close,
     })
+}
+
+/// Derive the regular trading session (epoch seconds) for the calendar
+/// day containing `anchor_ts`. Yahoo's `currentTradingPeriod.regular`
+/// gives the canonical open/close, but its *date* rolls forward to the
+/// next session once the market closes — so we take only its
+/// **time-of-day** and re-anchor it to the day the bars actually belong
+/// to. `gmtoffset` (the exchange's UTC offset, DST-correct for that
+/// day) converts between epoch and exchange-local wall clock, so this
+/// works for non-US exchanges too without a timezone database.
+fn session_for_day(meta: &Meta, anchor_ts: i64) -> Option<TradingSession> {
+    let gmt = meta.gmtoffset?;
+    let regular = meta.current_trading_period.as_ref()?.regular.as_ref()?;
+    let open = regular.start?;
+    let close = regular.end?;
+
+    const DAY: i64 = 86_400;
+    // Seconds since exchange-local midnight for the canonical open/close.
+    let open_tod = (open + gmt).rem_euclid(DAY);
+    let close_tod = (close + gmt).rem_euclid(DAY);
+    // Exchange-local midnight of the anchor day, back in epoch seconds.
+    let local_midnight = (anchor_ts + gmt) - (anchor_ts + gmt).rem_euclid(DAY) - gmt;
+
+    let start = local_midnight + open_tod;
+    let mut end = local_midnight + close_tod;
+    // Guard against a close-before-open wrap (shouldn't happen for a
+    // normal session, but keeps the renderer's span strictly positive).
+    if end <= start {
+        end += DAY;
+    }
+    Some(TradingSession { start, end })
 }
 
 #[derive(Debug, Deserialize)]
@@ -146,12 +207,33 @@ struct Chart {
 #[derive(Debug, Deserialize)]
 struct ChartResult {
     meta: Meta,
+    /// Parallel to `indicators.quote[0].close` — epoch seconds per bar.
+    /// Absent on some payloads, so default to empty.
+    #[serde(default)]
+    timestamp: Vec<i64>,
     indicators: Indicators,
 }
 #[derive(Debug, Deserialize)]
 struct Meta {
     #[serde(default, rename = "previousClose")]
     previous_close: Option<f64>,
+    /// Exchange UTC offset in seconds (DST-correct for the day).
+    #[serde(default)]
+    gmtoffset: Option<i64>,
+    #[serde(default, rename = "currentTradingPeriod")]
+    current_trading_period: Option<CurrentTradingPeriod>,
+}
+#[derive(Debug, Deserialize)]
+struct CurrentTradingPeriod {
+    #[serde(default)]
+    regular: Option<TradingPeriod>,
+}
+#[derive(Debug, Deserialize)]
+struct TradingPeriod {
+    #[serde(default)]
+    start: Option<i64>,
+    #[serde(default)]
+    end: Option<i64>,
 }
 #[derive(Debug, Deserialize)]
 struct Indicators {
@@ -178,8 +260,13 @@ mod tests {
                     "meta": {
                         "currency": "USD",
                         "symbol": "AAPL",
-                        "previousClose": 181.10
+                        "previousClose": 181.10,
+                        "gmtoffset": -14400,
+                        "currentTradingPeriod": {
+                            "regular": { "start": 1718026200, "end": 1718049600 }
+                        }
                     },
+                    "timestamp": [1718026200, 1718026500, 1718026800, 1718027100, 1718027400],
                     "indicators": {
                         "quote": [
                             {
@@ -201,6 +288,68 @@ mod tests {
         assert_eq!(parsed.closes.len(), 4);
         assert_eq!(parsed.last_close, 182.34);
         assert_eq!(parsed.previous_close, Some(181.10));
+    }
+
+    #[test]
+    fn timestamps_drop_in_lockstep_with_null_closes() {
+        let raw: RawResponse = serde_json::from_str(FIXTURE).expect("deserialize");
+        let parsed = parse_window(raw).expect("window");
+        // The 3rd close was null → its timestamp (…26800) is dropped too.
+        assert_eq!(parsed.times.len(), parsed.closes.len());
+        assert_eq!(
+            parsed.times,
+            vec![1718026200, 1718026500, 1718027100, 1718027400]
+        );
+    }
+
+    #[test]
+    fn session_anchors_to_the_bars_own_day() {
+        // The fixture's gmtoffset is -4h (ET, DST). The regular period's
+        // start time-of-day re-anchored to the bar day must equal the
+        // first bar (the open). End must be after start.
+        let raw: RawResponse = serde_json::from_str(FIXTURE).expect("deserialize");
+        let parsed = parse_window(raw).expect("window");
+        let s = parsed.session.expect("session derived");
+        assert_eq!(s.start, 1718026200, "session start == 9:30 open bar");
+        assert!(s.end > s.start);
+        // 9:30 → 16:00 is 6.5h = 23_400s.
+        assert_eq!(s.end - s.start, 23_400);
+    }
+
+    #[test]
+    fn session_reanchors_when_trading_period_rolls_forward() {
+        // Simulate an after-hours fetch: bars are from one day but
+        // currentTradingPeriod.regular has rolled to the *next* session.
+        // We should take only its time-of-day and re-anchor to the bars.
+        let json = r#"{"chart":{"result":[{
+            "meta":{
+                "gmtoffset":-14400,
+                "currentTradingPeriod":{"regular":{"start":1718112600,"end":1718136000}}
+            },
+            "timestamp":[1718026200, 1718049600],
+            "indicators":{"quote":[{"close":[180.0, 182.0]}]}
+        }]}}"#;
+        let raw: RawResponse = serde_json::from_str(json).unwrap();
+        let parsed = parse_window(raw).expect("window");
+        let s = parsed.session.expect("session");
+        // Re-anchored to the bar day, the open lands on 9:30 of that day.
+        assert_eq!(s.start, 1718026200);
+        assert_eq!(s.end - s.start, 23_400);
+    }
+
+    #[test]
+    fn missing_meta_yields_no_session_but_still_parses() {
+        // Closes with no gmtoffset/trading-period: times still captured,
+        // session is None, and the renderer falls back to even spacing.
+        let json = r#"{"chart":{"result":[{
+            "meta":{"previousClose":100.0},
+            "timestamp":[1,2,3],
+            "indicators":{"quote":[{"close":[100.0,101.0,102.0]}]}
+        }]}}"#;
+        let raw: RawResponse = serde_json::from_str(json).unwrap();
+        let parsed = parse_window(raw).expect("window");
+        assert_eq!(parsed.times.len(), 3);
+        assert!(parsed.session.is_none());
     }
 
     #[test]

--- a/src/lib/matrix/eink/f1.rs
+++ b/src/lib/matrix/eink/f1.rs
@@ -112,7 +112,8 @@ impl EinkF1Matrix {
         let m = margin(w);
         let cx = wi / 2;
 
-        let right = match &data.next_race {
+        let current_race = data.current_race(now);
+        let right = match current_race {
             Some(r) => format!("ROUND {}", r.round),
             None => "OFF-SEASON".to_string(),
         };
@@ -121,7 +122,7 @@ impl EinkF1Matrix {
         // Standings occupy the bottom; the race/champion banner the top.
         let standings_top = if data.standings.is_empty() { hi } else { hi - hi * 46 / 100 };
 
-        match &data.next_race {
+        match current_race {
             Some(race) => self.draw_race(&mut img, race, now, content_top, standings_top, fg),
             None => self.draw_offseason(&mut img, data, content_top, standings_top, fg),
         }

--- a/src/lib/matrix/eink/layout.rs
+++ b/src/lib/matrix/eink/layout.rs
@@ -263,6 +263,44 @@ pub fn sparkline(img: &mut RgbImage, x: i32, y: i32, w: i32, h: i32, series: &[f
     fill_rect(img, mx - 1, my - 1, 3, 3, color);
 }
 
+/// Like [`sparkline`], but each point carries its own normalized x
+/// position `fracs[i]` in `0.0..=1.0` instead of being evenly spaced.
+/// Used by the intraday (1D) stock row so a half-finished trading day
+/// fills only the elapsed portion of the plot width — the x-axis is
+/// time of day, not sample index. `series` and `fracs` must be the same
+/// length; values autoscale to the box height exactly as in `sparkline`.
+#[allow(clippy::too_many_arguments)]
+pub fn sparkline_timed(img: &mut RgbImage, x: i32, y: i32, w: i32, h: i32, series: &[f32], fracs: &[f32], color: Color) {
+    if series.len() != fracs.len() || series.len() < 2 || w < 2 || h < 1 {
+        return;
+    }
+    let (mut lo, mut hi) = (f32::INFINITY, f32::NEG_INFINITY);
+    for &v in series {
+        if v.is_finite() {
+            lo = lo.min(v);
+            hi = hi.max(v);
+        }
+    }
+    if !lo.is_finite() || !hi.is_finite() {
+        return;
+    }
+    let span = hi - lo;
+    let sx = |f: f32| x + ((w - 1) as f32 * f.clamp(0.0, 1.0)).round() as i32;
+    let sy = |v: f32| {
+        if span <= f32::EPSILON {
+            y + h / 2
+        } else {
+            y + h - 1 - ((v - lo) / span * (h - 1) as f32).round() as i32
+        }
+    };
+    for i in 1..series.len() {
+        draw_line(img, sx(fracs[i - 1]), sy(series[i - 1]), sx(fracs[i]), sy(series[i]), color);
+    }
+    // Newest-point marker rides the last sample's time position.
+    let last = series.len() - 1;
+    fill_rect(img, sx(fracs[last]) - 1, sy(series[last]) - 1, 3, 3, color);
+}
+
 /// Draw a badge — a small boxed label. `filled` inverts it (solid box with the
 /// text knocked out), which reads as a high-contrast alert on the panel.
 /// Returns the x just past the badge.

--- a/src/lib/matrix/eink/sport.rs
+++ b/src/lib/matrix/eink/sport.rs
@@ -37,7 +37,9 @@ use crate::matrix::error::RenderError;
 use async_trait::async_trait;
 use image::imageops::FilterType;
 use image::RgbImage;
-use std::collections::HashMap;
+use chrono::Local;
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
 use ohmyoled_matrix::graphics::{draw_text, Font};
 use ohmyoled_matrix::{Color, EinkDisplay};
 use std::path::{Path, PathBuf};
@@ -67,9 +69,16 @@ pub struct EinkSportMatrix {
     score: Font,
     status: Font,
     row: Font,
-    /// Fetched + resized team logos, keyed by team name. Populated lazily in
-    /// `render`; `frame` draws from it (abbreviation box on a miss).
-    logo_cache: HashMap<String, RgbImage>,
+    /// Fetched + resized team logos, keyed by team name. Populated by a
+    /// background task spawned from `render` (never on the render path); `frame`
+    /// draws from it (abbreviation box on a miss). Shared (`Arc<Mutex<…>>`) so
+    /// the spawned fetch can insert without blocking the display. A `std::Mutex`
+    /// is fine here — the guard is only ever held for a `get`/`insert`, never
+    /// across an `.await` — and `frame` is sync so it can't await a tokio lock.
+    logo_cache: Arc<Mutex<HashMap<String, RgbImage>>>,
+    /// Team names with a logo fetch currently in flight, so at most one task is
+    /// spawned per team even while the fetch is still pending.
+    logo_inflight: Arc<Mutex<HashSet<String>>>,
 }
 
 impl EinkSportMatrix {
@@ -90,23 +99,37 @@ impl EinkSportMatrix {
             score: Font::load_ttf(&paths.body, scaled_px(96.0, h))?,
             status: Font::load_ttf(&paths.body, scaled_px(26.0, h))?,
             row: Font::load_ttf(&paths.body, scaled_px(22.0, h))?,
-            logo_cache: HashMap::new(),
+            logo_cache: Arc::new(Mutex::new(HashMap::new())),
+            logo_inflight: Arc::new(Mutex::new(HashSet::new())),
         })
     }
 
-    /// Fetch + decode + resize a team's logo into the cache (idempotent). A
-    /// miss or failure leaves the renderer to draw the abbreviation box.
-    async fn ensure_logo(&mut self, side: &TeamSide) {
-        if self.logo_cache.contains_key(&side.name) {
+    /// Kick off a background fetch of a team's logo into the shared cache.
+    /// Returns immediately — never blocks the render path on the network. At
+    /// most one task is spawned per team (in-flight guard); a miss or failure
+    /// just leaves `frame` to draw the abbreviation box until the logo lands.
+    fn prefetch_logo(&self, side: &TeamSide) {
+        let Some(url) = side.logo_url.clone() else { return };
+        let name = side.name.clone();
+        // Already cached → nothing to do.
+        if self.logo_cache.lock().unwrap().contains_key(&name) {
             return;
         }
-        let Some(url) = side.logo_url.clone() else { return };
-        match fetch_logo(&url).await {
-            Ok(logo) => {
-                self.logo_cache.insert(side.name.clone(), logo);
-            }
-            Err(e) => log::warn!("eink sport: logo fetch failed for {} ({url}): {e}", side.name),
+        // Claim the in-flight slot; bail if another task is already fetching it.
+        if !self.logo_inflight.lock().unwrap().insert(name.clone()) {
+            return;
         }
+        let cache = Arc::clone(&self.logo_cache);
+        let inflight = Arc::clone(&self.logo_inflight);
+        tokio::spawn(async move {
+            match fetch_logo(&url).await {
+                Ok(logo) => {
+                    cache.lock().unwrap().insert(name.clone(), logo);
+                }
+                Err(e) => log::warn!("eink sport: logo fetch failed for {name} ({url}): {e}"),
+            }
+            inflight.lock().unwrap().remove(&name);
+        });
     }
 
     pub async fn with_fonts_async(paths: EinkSportFonts, dims: (u32, u32)) -> Result<Self, String> {
@@ -128,7 +151,7 @@ impl EinkSportMatrix {
 
         let standings_top = if data.standings.is_empty() { hi } else { hi - hi * 50 / 100 };
 
-        match &data.next_game {
+        match data.current_game(Local::now()) {
             Some(game) => self.draw_scoreboard(&mut img, game, content_top, standings_top, fg),
             None => {
                 let label = if data.standings.is_empty() {
@@ -160,6 +183,13 @@ impl EinkSportMatrix {
         // Everything hangs off the band's vertical center so the scoreboard
         // fills the space rather than hugging the top.
         let score_cy = top + band_h / 2;
+
+        // Playoff context (round/game headline + series score) pinned to the top
+        // of the band. Absent in the regular season, so this is postseason-only.
+        if let Some(note) = &game.playoff_note {
+            let note = fit_text(&self.status, &note.to_uppercase(), wi - 2 * m);
+            center_text(img, &self.status, cx, top + self.status.ascent(), fg, &note);
+        }
 
         // Team crest (logo if fetched, else an abbreviation box) + name,
         // vertically centered as a unit on the score line.
@@ -205,8 +235,9 @@ impl EinkSportMatrix {
     /// box with the abbreviation.
     fn draw_crest(&self, img: &mut RgbImage, cx: i32, box_top: i32, box_w: i32, side: &TeamSide, fg: Color) {
         let bx = cx - box_w / 2;
-        if let Some(logo) = self.logo_cache.get(&side.name) {
-            draw_logo_silhouette(img, logo, bx, box_top, box_w, fg);
+        let cached = self.logo_cache.lock().unwrap().get(&side.name).cloned();
+        if let Some(logo) = cached {
+            draw_logo_silhouette(img, &logo, bx, box_top, box_w, fg);
         } else {
             rect(img, bx, box_top, box_w, box_w, fg);
             center_text(img, &self.abbr, cx, box_top + box_w / 2 + self.abbr.ascent() / 2, fg, &side.abbreviation);
@@ -277,11 +308,12 @@ impl EinkRenderer for EinkSportMatrix {
     }
 
     async fn render(&mut self, display: &mut EinkDisplay, data: &SportData) -> Result<(), RenderError> {
-        // Fetch both teams' logos (cached) before composing.
-        if let Some(game) = &data.next_game {
-            let (home, away) = (game.home.clone(), game.away.clone());
-            self.ensure_logo(&home).await;
-            self.ensure_logo(&away).await;
+        // Kick off logo fetches in the background — never block the panel on
+        // the network. `frame` draws the abbreviation box until a logo lands.
+        // Only for a current game (off-season has no scoreboard to fill).
+        if let Some(game) = data.current_game(Local::now()) {
+            self.prefetch_logo(&game.home);
+            self.prefetch_logo(&game.away);
         }
         let img = self.frame(data, display.width(), display.height());
         display.show(&img);
@@ -290,10 +322,47 @@ impl EinkRenderer for EinkSportMatrix {
     }
 }
 
-/// HTTP fetch + decode + resize a logo to `LOGO_PX` square, composited onto a
-/// white background (so transparency reads as background for the silhouette).
+/// Square size every cached logo is normalized to.
+const LOGO_PX: u32 = 120;
+
+/// On-disk cache directory for processed logos. Honors `XDG_CACHE_HOME`, then
+/// `$HOME/.cache`, then `/tmp`. Team logos never change, so once a processed
+/// crest is written here it's reused across restarts with no network at all.
+fn logo_cache_dir() -> PathBuf {
+    let base = std::env::var_os("XDG_CACHE_HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".cache")))
+        .unwrap_or_else(|| PathBuf::from("/tmp"));
+    base.join("ohmyoled").join("logos")
+}
+
+/// Stable cache path for a logo URL at the current size. `DefaultHasher::new()`
+/// is fixed-seed (not `RandomState`), so the name is deterministic across runs.
+fn logo_cache_path(url: &str) -> PathBuf {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    url.hash(&mut h);
+    LOGO_PX.hash(&mut h);
+    logo_cache_dir().join(format!("{:016x}.png", h.finish()))
+}
+
+/// Load a processed logo: disk cache first (static, so a hit means zero
+/// network), otherwise HTTP fetch → decode → resize → composite, then write it
+/// back to disk so every subsequent run (this team, forever) is a disk hit.
 async fn fetch_logo(url: &str) -> Result<RgbImage, String> {
-    const LOGO_PX: u32 = 120;
+    let path = logo_cache_path(url);
+
+    // Disk hit — reuse the already-processed crest, no network.
+    let read_path = path.clone();
+    if let Ok(Ok(img)) = tokio::task::spawn_blocking(move || {
+        image::open(&read_path).map(|i| i.to_rgb8())
+    })
+    .await
+    {
+        log::debug!("eink sport: logo disk-cache hit for {url}");
+        return Ok(img);
+    }
+
     let bytes = shared_client()
         .get(url)
         .send()
@@ -313,6 +382,16 @@ async fn fetch_logo(url: &str) -> Result<RgbImage, String> {
             let a = p[3] as f32 / 255.0;
             let blend = |c: u8| (c as f32 * a + 255.0 * (1.0 - a)).round() as u8;
             out.put_pixel(x, y, image::Rgb([blend(p[0]), blend(p[1]), blend(p[2])]));
+        }
+        // Persist the processed crest (best-effort — a cache write failure must
+        // never fail the render; we just re-fetch next time).
+        if let Some(dir) = path.parent() {
+            let saved = std::fs::create_dir_all(dir)
+                .map_err(|e| e.to_string())
+                .and_then(|_| out.save(&path).map_err(|e| e.to_string()));
+            if let Err(e) = saved {
+                log::debug!("eink sport: logo cache write failed ({}): {e}", path.display());
+            }
         }
         Ok(out)
     })
@@ -355,6 +434,7 @@ mod tests {
                 home: side("76ers", "PHI", Some(88)),
                 away: side("Celtics", "BOS", Some(81)),
                 our_side: HomeOrAway::Home,
+                playoff_note: Some("EAST 1ST ROUND - Game 5 · Series tied 2-2".into()),
             }),
             standings: standings(),
         }

--- a/src/lib/matrix/eink/stock_chart.rs
+++ b/src/lib/matrix/eink/stock_chart.rs
@@ -27,6 +27,7 @@
 use crate::api::stock::model::{HistorySeries, StockHistory};
 use crate::matrix::eink::layout::{
     badge, badge_width, footer, header_band, margin, right_text, scaled_px, sparkline,
+    sparkline_timed,
 };
 use crate::matrix::eink_renderer::EinkRenderer;
 use crate::matrix::error::RenderError;
@@ -124,7 +125,21 @@ impl EinkStockChartMatrix {
                 let hl_w = self.pct.text_width(&format!("{:.0}", series.high)).max(self.pct.text_width(&format!("{:.0}", series.low)));
                 let plot_w = wi - m - plot_x - hl_w - m / 2;
                 let pts: Vec<f32> = series.closes.iter().map(|&v| v as f32).collect();
-                sparkline(&mut img, plot_x, plot_y, plot_w, plot_h, &pts, fg);
+                // The 1D row anchors x to the trading session (time of
+                // day) when the provider supplied intraday timestamps; a
+                // day in progress fills only the elapsed portion. Other
+                // rows (and crypto) keep even index spacing.
+                match series.intraday() {
+                    Some((_, times, sess)) if sess.end > sess.start => {
+                        let span = (sess.end - sess.start) as f32;
+                        let fracs: Vec<f32> = times
+                            .iter()
+                            .map(|&t| ((t - sess.start) as f32 / span).clamp(0.0, 1.0))
+                            .collect();
+                        sparkline_timed(&mut img, plot_x, plot_y, plot_w, plot_h, &pts, &fracs, fg);
+                    }
+                    _ => sparkline(&mut img, plot_x, plot_y, plot_w, plot_h, &pts, fg),
+                }
                 // High at the top-right, low at the bottom-right of the plot.
                 right_text(&mut img, &self.pct, wi - m, plot_y + self.pct.ascent(), fg, &format!("{:.0}", series.high));
                 right_text(&mut img, &self.pct, wi - m, plot_y + plot_h - self.pct.height() + self.pct.ascent(), fg, &format!("{:.0}", series.low));
@@ -170,6 +185,16 @@ mod tests {
         HistorySeries::from_closes((0..n).map(|i| base + i as f64 * slope).collect())
     }
 
+    fn intraday_series(n: usize, base: f64, slope: f64, fill_frac: f64) -> HistorySeries {
+        use crate::api::stock::model::TradingSession;
+        let closes: Vec<f64> = (0..n).map(|i| base + i as f64 * slope).collect();
+        let session = TradingSession { start: 0, end: 23_400 };
+        let times: Vec<i64> = (0..n)
+            .map(|i| (i as f64 / (n.max(2) - 1) as f64 * 23_400.0 * fill_frac).round() as i64)
+            .collect();
+        HistorySeries::from_samples(closes, times, Some(session))
+    }
+
     fn sample() -> StockHistory {
         StockHistory {
             api: StockApiSource::Yahoo,
@@ -198,6 +223,37 @@ mod tests {
         s.day = HistorySeries::from_closes(vec![]);
         let img = r.frame(&s, 800, 480);
         assert!(img.pixels().filter(|p| p.0 != [0, 0, 0]).count() > 200, "empty window still renders");
+    }
+
+    #[test]
+    fn intraday_day_row_leaves_trailing_space() {
+        // A 1D row half-elapsed should draw its sparkline only across the
+        // left portion of the plot; the trailing time hasn't happened.
+        // Compare lit pixels in the right quarter of the plot band vs a
+        // full session — the partial day must light fewer.
+        let r = EinkStockChartMatrix::with_fonts(repo_fonts(), (800, 480)).unwrap();
+        let mut partial = sample();
+        partial.day = intraday_series(40, 188.0, 0.15, 0.5);
+        let mut full = sample();
+        full.day = intraday_series(40, 188.0, 0.15, 1.0);
+
+        // The two samples differ *only* in the 1D row's x-positions
+        // (closes, labels, footer, and the 1M/1Y rows are identical), so
+        // any difference in right-side ink is the intraday sparkline.
+        let right_quarter_ink = |img: &RgbImage| -> usize {
+            let w = img.width();
+            let h = img.height();
+            ((w * 3 / 4)..w)
+                .flat_map(|x| (0..h).map(move |y| (x, y)))
+                .filter(|&(x, y)| img.get_pixel(x, y).0 != [0, 0, 0])
+                .count()
+        };
+        let p = right_quarter_ink(&r.frame(&partial, 800, 480));
+        let f = right_quarter_ink(&r.frame(&full, 800, 480));
+        assert!(
+            p < f,
+            "partial-day 1D row should light fewer right-side pixels than a full session ({p} vs {f})"
+        );
     }
 
     #[test]

--- a/src/lib/matrix/sport.rs
+++ b/src/lib/matrix/sport.rs
@@ -169,7 +169,7 @@ impl Renderer for SportMatrix {
             return Ok(());
         }
 
-        if let Some(ng) = &data.next_game {
+        if let Some(ng) = data.current_game(Local::now()) {
             self.ensure_logo(&ng.home).await;
             self.ensure_logo(&ng.away).await;
         }
@@ -196,7 +196,9 @@ impl SportMatrix {
     /// Render one composed frame at the given scroll offset.
     pub fn draw_frame(&self, data: &SportData, xpos: i32) -> RgbImage {
         let mut img = RgbImage::new(PANEL_W, PANEL_H);
-        if let Some(ng) = &data.next_game {
+        // Only the *current* game gets a scoreboard — a stale ESPN `next_event`
+        // (weeks-old final / next-season opener) falls through to standings only.
+        if let Some(ng) = data.current_game(Local::now()) {
             self.draw_top(&mut img, ng, xpos);
             self.draw_middle(&mut img, ng);
         }
@@ -281,7 +283,7 @@ impl SportMatrix {
         let font = &self.body_font;
         let baseline = top_to_baseline(25, font.ascent());
 
-        let text = if data.standings.is_empty() {
+        let standings_text = if data.standings.is_empty() {
             format!("{} ({}) {}", data.team_name, data.record, data.sport.display_name())
         } else {
             let mut parts: Vec<String> = data
@@ -291,6 +293,13 @@ impl SportMatrix {
                 .collect();
             parts.push(format!("({})", data.record));
             parts.join("  ")
+        };
+
+        // In the postseason, lead the marquee with the playoff round/series note
+        // (no spare rows on a 64×32 panel, so it shares the bottom scroll).
+        let text = match data.current_game(Local::now()).and_then(|g| g.playoff_note.as_deref()) {
+            Some(note) => format!("{note}  ·  {standings_text}"),
+            None => standings_text,
         };
 
         // Text width ≈ 4px/char for 04B_03B; loop scroll modulo total width.
@@ -452,7 +461,6 @@ fn decode_and_resize(bytes: &[u8]) -> Result<RgbImage, String> {
 mod tests {
     use super::*;
     use crate::api::sport::model::{SportApiSource, StandingsEntry};
-    use chrono::TimeZone;
     use std::path::PathBuf;
 
     fn repo_fonts() -> SportFonts {
@@ -466,7 +474,9 @@ mod tests {
     fn make_data(with_game: bool, with_standings: bool, status: GameStatus) -> SportData {
         let next_game = if with_game {
             Some(NextGame {
-                start: Local.with_ymd_and_hms(2024, 6, 15, 19, 30, 0).unwrap(),
+                // Near-now so the game counts as *current* (not stale); the exact
+                // wall-clock instant doesn't matter to these layout assertions.
+                start: Local::now(),
                 status,
                 home: TeamSide {
                     name: "Boston Celtics".into(),
@@ -481,6 +491,7 @@ mod tests {
                     score: Some(100),
                 },
                 our_side: HomeOrAway::Home,
+                playoff_note: None,
             })
         } else {
             None

--- a/src/lib/matrix/stock_chart.rs
+++ b/src/lib/matrix/stock_chart.rs
@@ -23,14 +23,20 @@
 //!   read like a rolling caption while the dominant numbers stay
 //!   visible at rest.
 //! - **Graph (bottom 24 px)**: line drawn between consecutive closes.
-//!   The series is bucketed across the 62-px-wide plotting area so a
-//!   ~78-sample intraday window and a ~52-sample yearly window both
-//!   compress cleanly. Y-axis autoscales to that window's `low`/`high`
-//!   — a flat 1D doesn't get dwarfed by a volatile 1Y. Color follows
-//!   the window's own direction (`closes[0]` vs `closes[last]`).
-//! - **Current-price marker**: a 2 px triangle at the right edge of
-//!   the active window. Always white so the "where we are now" reads
-//!   independent of the line color.
+//!   Y-axis autoscales to that window's `low`/`high` — a flat 1D
+//!   doesn't get dwarfed by a volatile 1Y. Color follows the window's
+//!   own direction (`closes[0]` vs `closes[last]`). The x-axis depends
+//!   on the window:
+//!   - **1D (intraday)**: anchored to the regular trading session
+//!     (9:30 AM → 4:00 PM, from the provider's session bounds). Each
+//!     close lands at its real time of day, so a day still in progress
+//!     fills only the elapsed left portion and the rest stays blank.
+//!   - **1M / 1Y (and crypto)**: bucketed evenly across the 62-px
+//!     plotting area so the whole window always spans the graph.
+//! - **Current-price marker**: a 2 px triangle at the newest sample —
+//!   the right edge for completed/even-spaced windows, or wherever
+//!   "now" falls on the intraday time axis. Always white so the "where
+//!   we are now" reads independent of the line color.
 //! - **Period cycle**: 12 s render cycle ⇒ 4 s on each of 1D, 1M, 1Y,
 //!   then return. Empty windows render a "NO DATA" badge in their
 //!   slot instead of an empty graph.
@@ -295,9 +301,6 @@ impl StockChartMatrix {
             Direction::Flat => FLAT,
         };
 
-        let width_px = (GRAPH_RIGHT - GRAPH_LEFT + 1) as usize;
-        let buckets = bucket_to_width(&series.closes, width_px);
-
         // Vertical scaling: clamp degenerate ranges so a flat series
         // draws a horizontal stripe rather than dividing by zero.
         let mut lo = series.low;
@@ -313,6 +316,39 @@ impl StockChartMatrix {
             // Invert: higher price = smaller y (closer to top of graph).
             GRAPH_BOTTOM - (t * (GRAPH_BOTTOM - GRAPH_TOP) as f64).round() as i32
         };
+
+        // Intraday (1D) path: anchor x to the trading session so a
+        // half-finished day fills only the elapsed portion of the axis.
+        if let Some((closes, times, session)) = series.intraday() {
+            if session.end > session.start {
+                let span = (session.end - session.start) as f64;
+                let to_x = |ts: i64| -> i32 {
+                    let t = ((ts - session.start) as f64 / span).clamp(0.0, 1.0);
+                    GRAPH_LEFT + (t * (GRAPH_RIGHT - GRAPH_LEFT) as f64).round() as i32
+                };
+                let mut prev: Option<(i32, i32)> = None;
+                for (i, &price) in closes.iter().enumerate() {
+                    let pt = (to_x(times[i]), to_y(price));
+                    if let Some((px, py)) = prev {
+                        draw_line(img, px, py, pt.0, pt.1, color);
+                    }
+                    prev = Some(pt);
+                }
+                // Marker rides the newest sample — wherever "now" sits on
+                // the time axis, not pinned to the right edge.
+                if let Some((mx, my)) = prev {
+                    put(img, mx, my, MARKER);
+                    put(img, mx - 1, my, MARKER);
+                    put(img, mx, my - 1, MARKER);
+                }
+                return;
+            }
+        }
+
+        // Even-spacing path (1M / 1Y / crypto): bucket across the full
+        // width so the whole window always spans the graph.
+        let width_px = (GRAPH_RIGHT - GRAPH_LEFT + 1) as usize;
+        let buckets = bucket_to_width(&series.closes, width_px);
 
         // Draw connected segments. With buckets.len() == width_px,
         // each segment is one pixel wide.
@@ -530,7 +566,7 @@ fn put(img: &mut RgbImage, x: i32, y: i32, c: Color) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::stock::model::StockApiSource;
+    use crate::api::stock::model::{StockApiSource, TradingSession};
     use std::path::PathBuf;
 
     fn repo_fonts() -> StockChartFonts {
@@ -554,6 +590,67 @@ mod tests {
             month,
             year,
         }
+    }
+
+    /// Build an intraday day series whose samples span `fill_frac` of
+    /// the `[start, end]` session — `fill_frac < 1.0` models a trading
+    /// day still in progress.
+    fn intraday(closes: Vec<f64>, start: i64, end: i64, fill_frac: f64) -> HistorySeries {
+        let n = closes.len().max(2);
+        let span = (end - start) as f64;
+        let times: Vec<i64> = (0..closes.len())
+            .map(|i| start + (i as f64 / (n - 1) as f64 * span * fill_frac).round() as i64)
+            .collect();
+        HistorySeries::from_samples(closes, times, Some(TradingSession { start, end }))
+    }
+
+    /// Count non-black graph-area pixels in the column range `xs`.
+    fn graph_lit_in_cols(img: &RgbImage, xs: std::ops::Range<u32>) -> usize {
+        xs.flat_map(|x| (GRAPH_TOP as u32..=GRAPH_BOTTOM as u32).map(move |y| (x, y)))
+            .filter(|&(x, y)| img.get_pixel(x, y).0 != [0, 0, 0])
+            .count()
+    }
+
+    #[test]
+    fn intraday_half_day_leaves_right_half_empty() {
+        // A session half-elapsed should draw a line only across the left
+        // ~half of the graph; the trailing time hasn't happened yet.
+        let m = StockChartMatrix::with_fonts(repo_fonts()).expect("fonts");
+        let day = intraday((0..40).map(|i| 180.0 + i as f64 * 0.05).collect(), 0, 23_400, 0.5);
+        let h = sample(day, ramp(170.0, 0.5, 22), ramp(140.0, 0.8, 52));
+        let img = m.draw_frame(&h, Period::Day, 0);
+        let left = graph_lit_in_cols(&img, (GRAPH_LEFT as u32)..32);
+        let right = graph_lit_in_cols(&img, 40..(GRAPH_RIGHT as u32 + 1));
+        assert!(left > 10, "left half should carry the line, got {left}");
+        assert_eq!(right, 0, "right half (future time) must stay empty, got {right}");
+    }
+
+    #[test]
+    fn intraday_full_session_spans_the_width() {
+        // A completed session reaches the right edge — the marker sits at
+        // GRAPH_RIGHT just like the bucketed windows.
+        let m = StockChartMatrix::with_fonts(repo_fonts()).expect("fonts");
+        let day = intraday((0..78).map(|i| 180.0 + i as f64 * 0.05).collect(), 0, 23_400, 1.0);
+        let h = sample(day, ramp(170.0, 0.5, 22), ramp(140.0, 0.8, 52));
+        let img = m.draw_frame(&h, Period::Day, 0);
+        // The right-edge column should be lit (marker + line tail).
+        let right_edge = graph_lit_in_cols(&img, (GRAPH_RIGHT as u32)..(GRAPH_RIGHT as u32 + 1));
+        assert!(right_edge > 0, "full session should reach the right edge");
+    }
+
+    #[test]
+    fn month_window_ignores_intraday_and_fills_width() {
+        // The month series has no timestamps → even-spacing path → line
+        // spans the whole width regardless of time of day.
+        let m = StockChartMatrix::with_fonts(repo_fonts()).expect("fonts");
+        let h = sample(
+            intraday((0..40).map(|i| 180.0 + i as f64 * 0.05).collect(), 0, 23_400, 0.5),
+            ramp(170.0, 0.5, 22),
+            ramp(140.0, 0.8, 52),
+        );
+        let img = m.draw_frame(&h, Period::Month, 0);
+        let right = graph_lit_in_cols(&img, 40..(GRAPH_RIGHT as u32 + 1));
+        assert!(right > 5, "month window should fill the full width, got {right}");
     }
 
     #[test]

--- a/src/lib/modules/mod.rs
+++ b/src/lib/modules/mod.rs
@@ -29,6 +29,7 @@ pub mod eink_module;
 pub mod error;
 pub mod registry;
 pub mod scheduler;
+pub mod sleep;
 
 use crate::api::Collector;
 use crate::matrix::Renderer;
@@ -208,6 +209,12 @@ async fn background_poll<C>(
         if tx.is_closed() {
             log::debug!("[{id}] watch receivers dropped; stopping poll task");
             return;
+        }
+        // Pause polling while the daemon is asleep — no API calls until wake.
+        if crate::modules::sleep::is_sleeping() {
+            log::debug!("[{id}] asleep; pausing polls until wake");
+            crate::modules::sleep::wait_until_awake().await;
+            continue;
         }
         let started = std::time::Instant::now();
         match collector.poll().await {

--- a/src/lib/modules/registry.rs
+++ b/src/lib/modules/registry.rs
@@ -838,6 +838,60 @@ fn default_eink_threshold() -> u8 {
     128
 }
 
+/// Optional "sleep mode" schedule. When `enabled`, the daemon blanks **both**
+/// panels and pauses **all** API polling while the schedule says it's asleep.
+///
+/// Three schedule shapes are supported and OR'd together — it's asleep if *any*
+/// of them matches the current (system local) time:
+///
+/// - **Cron pair** — `sleep` / `wake` crontab expressions mark the instants the
+///   daemon enters and leaves sleep. Handles overnight windows naturally
+///   (e.g. `sleep: "0 22 * * *"`, `wake: "0 7 * * *"`).
+/// - **HH:MM window** — plain `start` / `end` clock times; wraps past midnight
+///   when `start > end`.
+/// - **Cron windows** — each [`SleepWindow`] fires on its `at` cron and keeps the
+///   panels off for `for_mins` minutes afterwards.
+///
+/// All times are evaluated against the system local clock (`chrono::Local`).
+///
+/// ```yaml
+/// sleep:
+///   enabled: true
+///   sleep: "0 22 * * *"   # 10:00 PM — panels off
+///   wake:  "0 7 * * *"    # 7:00 AM — back on
+/// ```
+#[derive(Debug, Deserialize, Default)]
+pub struct SleepConfig {
+    /// Master switch. Off (the default) leaves every existing config unchanged.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Cron expression that ENTERS sleep (pairs with `wake`).
+    #[serde(default, deserialize_with = "crate::serde_helpers::null_string_as_none")]
+    pub sleep: Option<String>,
+    /// Cron expression that WAKES (pairs with `sleep`).
+    #[serde(default, deserialize_with = "crate::serde_helpers::null_string_as_none")]
+    pub wake: Option<String>,
+    /// `HH:MM` window start (pairs with `end`; wraps past midnight).
+    #[serde(default, deserialize_with = "crate::serde_helpers::null_string_as_none")]
+    pub start: Option<String>,
+    /// `HH:MM` window end (pairs with `start`).
+    #[serde(default, deserialize_with = "crate::serde_helpers::null_string_as_none")]
+    pub end: Option<String>,
+    /// Cron-anchored windows, each asleep for `for_mins` after it fires.
+    #[serde(default)]
+    pub windows: Vec<SleepWindow>,
+}
+
+/// One cron-anchored sleep window: asleep for `for_mins` minutes after each
+/// firing of the `at` cron expression.
+#[derive(Debug, Deserialize, Clone)]
+pub struct SleepWindow {
+    /// Crontab expression marking the start of the window.
+    pub at: String,
+    /// How long the window stays asleep, in minutes.
+    pub for_mins: u64,
+}
+
 impl EinkRegistryConfig {
     /// Convert to the matrix crate's panel options.
     pub fn options(&self) -> ohmyoled_matrix::EinkOptions {

--- a/src/lib/modules/scheduler.rs
+++ b/src/lib/modules/scheduler.rs
@@ -7,6 +7,7 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::modules::eink_module::DynEinkModule;
+use crate::modules::sleep;
 use crate::modules::{DynModule, error::ModuleError};
 use ohmyoled_matrix::{EinkDisplay, RGBMatrix};
 
@@ -61,6 +62,15 @@ pub async fn run(mut matrix: RGBMatrix, mut modules: Vec<Box<dyn DynModule>>) ->
 
     let mut cycle: u64 = 0;
     loop {
+        // Sleep mode: blank the panel and park until wake. The LED path exits
+        // via the libc signal handler, so there's no shutdown race to honor.
+        if sleep::is_sleeping() {
+            log::info!("scheduler: asleep; blanking panel until wake");
+            matrix.clear();
+            sleep::wait_until_awake().await;
+            log::info!("scheduler: awake; resuming");
+            continue;
+        }
         cycle = cycle.wrapping_add(1);
         log::debug!("scheduler: cycle {cycle} begin");
         let started = std::time::Instant::now();
@@ -111,6 +121,19 @@ pub async fn run_eink(
 
     let mut cycle: u64 = 0;
     'outer: loop {
+        // Sleep mode: blank the panel once, then park until wake — but keep
+        // honoring shutdown while parked so SIGINT still clears and exits.
+        if sleep::is_sleeping() {
+            log::info!("eink scheduler: asleep; blanking panel until wake");
+            display.clear();
+            tokio::select! {
+                _ = sleep::wait_until_awake() => {
+                    log::info!("eink scheduler: awake; resuming");
+                    continue 'outer;
+                }
+                _ = await_shutdown() => break 'outer,
+            }
+        }
         cycle = cycle.wrapping_add(1);
         log::debug!("eink scheduler: cycle {cycle} begin");
         let started = std::time::Instant::now();

--- a/src/lib/modules/sleep.rs
+++ b/src/lib/modules/sleep.rs
@@ -1,0 +1,328 @@
+//! Sleep mode — a schedule-driven global gate that blanks both panels and
+//! pauses all API polling during configured "asleep" windows.
+//!
+//! ## How it fits together
+//!
+//! A single process-wide [`watch::channel<bool>`] is the gate (mirroring the
+//! `SHUTDOWN`/`EINK_ACTIVE` atomics in [`scheduler`](crate::modules::scheduler),
+//! but `watch` so consumers can *await* a wake transition rather than spin):
+//!
+//! - The per-module background poll loop ([`background_poll`](crate::modules))
+//!   checks [`is_sleeping`] and parks on [`wait_until_awake`] instead of
+//!   hitting the network.
+//! - Both schedulers ([`scheduler::run`](crate::modules::scheduler::run) and
+//!   [`run_eink`](crate::modules::scheduler::run_eink)) blank the panel once on
+//!   entering sleep and park on [`wait_until_awake`] until the wake transition.
+//!
+//! A supervisor task re-evaluates the [`SleepSchedule`] every 30 s (cron is
+//! minute-resolution) and publishes state changes. Evaluation is *stateless*
+//! (`is_asleep(now)` recomputed from scratch), so it survives clock jumps from
+//! NTP / a Docker host suspend without drifting.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use chrono::{DateTime, Local, NaiveTime};
+use croner::Cron;
+use std::str::FromStr;
+use tokio::sync::watch;
+
+use crate::modules::registry::{SleepConfig, SleepWindow};
+
+/// Re-evaluation cadence for the supervisor. Cron resolves to the minute, so a
+/// sub-minute tick is plenty to catch every transition promptly.
+const TICK: Duration = Duration::from_secs(30);
+
+/// Process-wide gate. `None` until [`init`] runs (sleep disabled / not
+/// configured), in which case the daemon is always considered awake.
+static GATE: OnceLock<watch::Sender<bool>> = OnceLock::new();
+
+/// Whether the daemon is currently in a sleep window. `false` when sleep mode
+/// is disabled or unconfigured.
+pub fn is_sleeping() -> bool {
+    GATE.get().map(|tx| *tx.borrow()).unwrap_or(false)
+}
+
+/// Await until the gate reports awake. Returns immediately when sleep mode is
+/// disabled (no gate) or already awake; otherwise parks until the supervisor
+/// flips the gate back to `false` (or the gate is torn down).
+pub async fn wait_until_awake() {
+    if let Some(tx) = GATE.get() {
+        let mut rx = tx.subscribe();
+        while *rx.borrow_and_update() {
+            if rx.changed().await.is_err() {
+                return; // sender gone — treat as awake so we never wedge.
+            }
+        }
+    }
+}
+
+/// Parse the config into a [`SleepSchedule`], seed the gate with the current
+/// state, and spawn the supervisor.
+///
+/// Call this **before** building the registries so the spawned poll tasks see
+/// the gate immediately and don't fire a poll during a cold-start sleep window.
+/// A malformed schedule logs an error and leaves sleep disabled (gate unset, so
+/// the daemon behaves exactly as it did before).
+pub fn init(cfg: &SleepConfig) {
+    let schedule = match SleepSchedule::from_config(cfg) {
+        Ok(s) => s,
+        Err(e) => {
+            log::error!("sleep: invalid schedule, sleep mode disabled: {e}");
+            return;
+        }
+    };
+    if schedule.is_empty() {
+        log::warn!("sleep: enabled but no schedule shapes configured; sleep mode is a no-op");
+        return;
+    }
+    let initial = schedule.is_asleep(Local::now());
+    let (tx, _rx) = watch::channel(initial);
+    if GATE.set(tx).is_err() {
+        log::warn!("sleep: already initialized; ignoring duplicate init");
+        return;
+    }
+    log::info!(
+        "sleep mode enabled (currently {})",
+        if initial { "asleep — panels off" } else { "awake" }
+    );
+    tokio::spawn(supervisor(schedule));
+}
+
+/// Re-evaluate the schedule on a fixed cadence and publish transitions.
+async fn supervisor(schedule: SleepSchedule) {
+    loop {
+        tokio::time::sleep(TICK).await;
+        let asleep = schedule.is_asleep(Local::now());
+        if let Some(tx) = GATE.get() {
+            if *tx.borrow() != asleep {
+                log::info!(
+                    "sleep mode: {}",
+                    if asleep { "entering sleep — panels off" } else { "waking" }
+                );
+                let _ = tx.send(asleep);
+            }
+        }
+    }
+}
+
+/// A parsed sleep schedule. Built once from [`SleepConfig`]; [`is_asleep`] is
+/// pure and cheap so the supervisor can call it on every tick.
+///
+/// [`is_asleep`]: SleepSchedule::is_asleep
+pub struct SleepSchedule {
+    /// `(enter, wake)` cron pair — asleep while the next event is a wake.
+    cron_pair: Option<(Cron, Cron)>,
+    /// `[start, end)` clock window, wrapping past midnight when `start > end`.
+    clock_window: Option<(NaiveTime, NaiveTime)>,
+    /// Cron-anchored windows: asleep for `for_mins` after each firing.
+    windows: Vec<(Cron, chrono::Duration)>,
+}
+
+impl SleepSchedule {
+    /// Parse and validate every configured shape. Returns an error (and the
+    /// caller disables sleep) if any cron / time string is malformed.
+    pub fn from_config(cfg: &SleepConfig) -> Result<Self, String> {
+        let parse_cron = |label: &str, expr: &str| -> Result<Cron, String> {
+            Cron::from_str(expr).map_err(|e| format!("{label} cron '{expr}': {e}"))
+        };
+
+        let cron_pair = match (&cfg.sleep, &cfg.wake) {
+            (Some(s), Some(w)) => Some((parse_cron("sleep", s)?, parse_cron("wake", w)?)),
+            (Some(_), None) | (None, Some(_)) => {
+                return Err("`sleep` and `wake` must both be set (cron pair)".to_string());
+            }
+            (None, None) => None,
+        };
+
+        let parse_time = |label: &str, s: &str| -> Result<NaiveTime, String> {
+            NaiveTime::parse_from_str(s, "%H:%M")
+                .map_err(|e| format!("{label} time '{s}' (expected HH:MM): {e}"))
+        };
+        let clock_window = match (&cfg.start, &cfg.end) {
+            (Some(s), Some(e)) => Some((parse_time("start", s)?, parse_time("end", e)?)),
+            (Some(_), None) | (None, Some(_)) => {
+                return Err("`start` and `end` must both be set (HH:MM window)".to_string());
+            }
+            (None, None) => None,
+        };
+
+        let windows = cfg
+            .windows
+            .iter()
+            .map(|w: &SleepWindow| {
+                let cron = parse_cron("window", &w.at)?;
+                Ok((cron, chrono::Duration::minutes(w.for_mins as i64)))
+            })
+            .collect::<Result<Vec<_>, String>>()?;
+
+        Ok(Self { cron_pair, clock_window, windows })
+    }
+
+    /// True when nothing is configured (sleep mode would be a no-op).
+    pub fn is_empty(&self) -> bool {
+        self.cron_pair.is_none() && self.clock_window.is_none() && self.windows.is_empty()
+    }
+
+    /// Whether `now` falls inside any configured sleep window.
+    pub fn is_asleep(&self, now: DateTime<Local>) -> bool {
+        self.cron_pair_asleep(now) || self.clock_window_asleep(now) || self.windows_asleep(now)
+    }
+
+    /// Cron pair: the next event being a *wake* means we're inside a sleep
+    /// period. A cron error (no occurrence in croner's search horizon) is
+    /// treated as "not asleep" so a flaky expression can't pin the panel off.
+    fn cron_pair_asleep(&self, now: DateTime<Local>) -> bool {
+        let Some((enter, wake)) = &self.cron_pair else { return false };
+        match (
+            enter.find_next_occurrence(&now, false),
+            wake.find_next_occurrence(&now, false),
+        ) {
+            (Ok(next_enter), Ok(next_wake)) => next_wake < next_enter,
+            _ => false,
+        }
+    }
+
+    /// HH:MM window, with overnight wrap when `start > end`.
+    fn clock_window_asleep(&self, now: DateTime<Local>) -> bool {
+        let Some((start, end)) = &self.clock_window else { return false };
+        let t = now.time();
+        if start <= end {
+            t >= *start && t < *end
+        } else {
+            // Wraps midnight, e.g. 22:00..07:00.
+            t >= *start || t < *end
+        }
+    }
+
+    /// Cron windows: asleep if the most recent firing is still within its
+    /// `for_mins` span.
+    fn windows_asleep(&self, now: DateTime<Local>) -> bool {
+        self.windows.iter().any(|(cron, dur)| {
+            match cron.find_previous_occurrence(&now, true) {
+                Ok(last) => now < last + *dur,
+                Err(_) => false,
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use crate::modules::registry::SleepConfig;
+
+    fn at(h: u32, m: u32) -> DateTime<Local> {
+        // 2026-06-15 is a Monday; fixed so tests never touch the wall clock.
+        Local.with_ymd_and_hms(2026, 6, 15, h, m, 0).unwrap()
+    }
+
+    fn cfg() -> SleepConfig {
+        SleepConfig::default()
+    }
+
+    #[test]
+    fn overnight_clock_window_wraps_midnight() {
+        let s = SleepSchedule::from_config(&SleepConfig {
+            enabled: true,
+            start: Some("22:00".into()),
+            end: Some("07:00".into()),
+            ..cfg()
+        })
+        .unwrap();
+        assert!(s.is_asleep(at(23, 0)), "23:00 is inside 22:00-07:00");
+        assert!(s.is_asleep(at(2, 30)), "02:30 is inside the wrapped window");
+        assert!(s.is_asleep(at(22, 0)), "start is inclusive");
+        assert!(!s.is_asleep(at(7, 0)), "end is exclusive");
+        assert!(!s.is_asleep(at(12, 0)), "noon is awake");
+    }
+
+    #[test]
+    fn same_day_clock_window() {
+        let s = SleepSchedule::from_config(&SleepConfig {
+            enabled: true,
+            start: Some("13:00".into()),
+            end: Some("14:00".into()),
+            ..cfg()
+        })
+        .unwrap();
+        assert!(s.is_asleep(at(13, 30)));
+        assert!(!s.is_asleep(at(12, 59)));
+        assert!(!s.is_asleep(at(14, 0)));
+    }
+
+    #[test]
+    fn cron_pair_across_boundary() {
+        let s = SleepSchedule::from_config(&SleepConfig {
+            enabled: true,
+            sleep: Some("0 22 * * *".into()),
+            wake: Some("0 7 * * *".into()),
+            ..cfg()
+        })
+        .unwrap();
+        // At 23:00 the next event is the 07:00 wake → asleep.
+        assert!(s.is_asleep(at(23, 0)));
+        assert!(s.is_asleep(at(3, 0)));
+        // At 12:00 the next event is the 22:00 sleep → awake.
+        assert!(!s.is_asleep(at(12, 0)));
+        assert!(!s.is_asleep(at(7, 30)));
+    }
+
+    #[test]
+    fn cron_window_duration() {
+        let s = SleepSchedule::from_config(&SleepConfig {
+            enabled: true,
+            windows: vec![SleepWindow { at: "0 13 * * *".into(), for_mins: 60 }],
+            ..cfg()
+        })
+        .unwrap();
+        assert!(s.is_asleep(at(13, 0)), "fires at 13:00");
+        assert!(s.is_asleep(at(13, 59)), "still within the 60-min window");
+        assert!(!s.is_asleep(at(14, 0)), "window has elapsed");
+        assert!(!s.is_asleep(at(12, 59)), "before the window");
+    }
+
+    #[test]
+    fn shapes_are_ored_together() {
+        let s = SleepSchedule::from_config(&SleepConfig {
+            enabled: true,
+            start: Some("22:00".into()),
+            end: Some("07:00".into()),
+            windows: vec![SleepWindow { at: "0 13 * * *".into(), for_mins: 30 }],
+            ..cfg()
+        })
+        .unwrap();
+        assert!(s.is_asleep(at(23, 0)), "matched by clock window");
+        assert!(s.is_asleep(at(13, 15)), "matched by cron window");
+        assert!(!s.is_asleep(at(15, 0)), "matched by neither");
+    }
+
+    #[test]
+    fn empty_schedule_is_never_asleep() {
+        let s = SleepSchedule::from_config(&SleepConfig { enabled: true, ..cfg() }).unwrap();
+        assert!(s.is_empty());
+        assert!(!s.is_asleep(at(3, 0)));
+    }
+
+    #[test]
+    fn half_configured_pair_is_an_error() {
+        let r = SleepSchedule::from_config(&SleepConfig {
+            enabled: true,
+            sleep: Some("0 22 * * *".into()),
+            ..cfg()
+        });
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn malformed_cron_is_an_error() {
+        let r = SleepSchedule::from_config(&SleepConfig {
+            enabled: true,
+            sleep: Some("not a cron".into()),
+            wake: Some("0 7 * * *".into()),
+            ..cfg()
+        });
+        assert!(r.is_err());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ mod logger;
 mod preview;
 extern crate log;
 use clap::{Arg, ArgAction, Command};
-use oledlib::modules::{registry, scheduler};
+use oledlib::modules::{registry, scheduler, sleep};
 use ohmyoled_matrix::{EinkDisplay, EinkMode, MatrixMode, MatrixOptions, RGBMatrix};
 use std::io::IsTerminal;
 
@@ -169,6 +169,15 @@ struct EinkTopConfig {
     eink: registry::EinkRegistryConfig,
 }
 
+/// Pulls just the top-level `sleep` block out of the config (same separate-pass
+/// pattern as [`EinkTopConfig`]). Configs without a `sleep` key parse to the
+/// disabled default, so sleep mode is fully opt-in.
+#[derive(serde::Deserialize, Default)]
+struct SleepTopConfig {
+    #[serde(default)]
+    sleep: registry::SleepConfig,
+}
+
 #[tokio::main]
 async fn main() {
     let cmd = Command::new("ohmyoled").version(env!("CARGO_PKG_VERSION"));
@@ -328,6 +337,11 @@ async fn main() {
             println!("Failed to deserialize eink config at {}: {}", e.path(), e.inner());
             std::process::exit(35);
         });
+    let sleep_top: SleepTopConfig = serde_path_to_error::deserialize(configuration.clone())
+        .unwrap_or_else(|e| {
+            println!("Failed to deserialize sleep config at {}: {}", e.path(), e.inner());
+            std::process::exit(36);
+        });
     let registry_cfg: registry::RegistryConfig = serde_path_to_error::deserialize(configuration)
         .unwrap_or_else(|e| {
             println!(
@@ -339,6 +353,13 @@ async fn main() {
         });
     let dev = std::env::var("DEV").is_ok();
     install_signal_handlers();
+
+    // Sleep mode (opt-in): seed the gate and spawn the supervisor BEFORE the
+    // registries are built, so the modules' poll tasks observe the gate from
+    // their first tick and don't fire a poll during a cold-start sleep window.
+    if sleep_top.sleep.enabled {
+        sleep::init(&sleep_top.sleep);
+    }
 
     // The LED matrix and the e-paper display are independent outputs that can
     // run at the same time (they're separate physical panels). `eink.enabled`

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -53,7 +53,7 @@ use oledlib::matrix::launch::{LaunchFonts, LaunchMatrix};
 use oledlib::matrix::pihole::{PiholeFonts, PiholeMatrix};
 use oledlib::matrix::quake::{QuakeFonts, QuakeMatrix};
 use oledlib::matrix::sport::{SportFonts, SportMatrix};
-use oledlib::api::stock::{HistorySeries, StockHistory};
+use oledlib::api::stock::{HistorySeries, StockHistory, TradingSession};
 use oledlib::matrix::stock::{StockFonts, StockMatrix};
 use oledlib::matrix::stock_chart::{StockChartFonts, StockChartMatrix};
 use oledlib::matrix::time::TimeSnapshot;
@@ -444,7 +444,9 @@ async fn preview_eink_stock_chart(display: &mut EinkDisplay, fonts: &Path) -> Re
         symbol: "AAPL".into(),
         current: 191.2,
         previous_close: 190.0,
-        day: series(24, 188.0, 0.2),
+        // ~70% through the trading day so the 1D row's time-anchored
+        // x-axis shows blank trailing space.
+        day: intraday_day(series(24, 188.0, 0.2).closes, 0.70),
         month: series(30, 180.0, 0.5),
         year: series(52, 150.0, 0.9),
     };
@@ -617,6 +619,19 @@ async fn preview_stock(matrix: &mut RGBMatrix, fonts: &Path) -> Result<(), Strin
     }
 }
 
+/// Build a 1D `HistorySeries` whose samples span `fill_frac` of a
+/// 9:30→4:00 (6.5 h) session — `fill_frac < 1.0` models a trading day
+/// still in progress so the chart's time-anchored x-axis is visible.
+fn intraday_day(closes: Vec<f64>, fill_frac: f64) -> HistorySeries {
+    const SESSION_SECS: f64 = 23_400.0; // 6.5 h
+    let session = TradingSession { start: 0, end: SESSION_SECS as i64 };
+    let n = closes.len().max(2);
+    let times: Vec<i64> = (0..closes.len())
+        .map(|i| (i as f64 / (n - 1) as f64 * SESSION_SECS * fill_frac).round() as i64)
+        .collect();
+    HistorySeries::from_samples(closes, times, Some(session))
+}
+
 async fn preview_stock_chart(matrix: &mut RGBMatrix, fonts: &Path) -> Result<(), String> {
     let mut r = StockChartMatrix::with_fonts_async(StockChartFonts {
         body: fonts.join("04B_03B_.TTF"),
@@ -626,7 +641,10 @@ async fn preview_stock_chart(matrix: &mut RGBMatrix, fonts: &Path) -> Result<(),
     // 1D = noisy intraday wave that closes up; 1M = clear uptrend
     // with a midmonth dip; 1Y = steady climb. Lets the preview verify
     // the autoscale and direction-color logic across all three.
-    let day: Vec<f64> = (0..78)
+    // 1D is a trading day ~70% elapsed: the line fills the left ~70% of
+    // the axis (9:30 → ~2:00 PM) and the rest stays blank, exercising the
+    // time-anchored intraday path. 1M/1Y keep even index spacing.
+    let day: Vec<f64> = (0..55)
         .map(|i| 180.0 + (i as f64 * 0.12).sin() * 1.2 + i as f64 * 0.03)
         .collect();
     let month: Vec<f64> = (0..22)
@@ -640,7 +658,7 @@ async fn preview_stock_chart(matrix: &mut RGBMatrix, fonts: &Path) -> Result<(),
         symbol: "AAPL".into(),
         current: *day.last().unwrap(),
         previous_close: day[0],
-        day: HistorySeries::from_closes(day),
+        day: intraday_day(day, 0.70),
         month: HistorySeries::from_closes(month),
         year: HistorySeries::from_closes(year),
     };

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -477,6 +477,7 @@ async fn preview_eink_sport(display: &mut EinkDisplay, fonts: &Path) -> Result<(
             home: TeamSide { name: "76ers".into(), abbreviation: "PHI".into(), logo_url: None, score: Some(88) },
             away: TeamSide { name: "Celtics".into(), abbreviation: "BOS".into(), logo_url: None, score: Some(81) },
             our_side: HomeOrAway::Home,
+            playoff_note: Some("EAST 1ST ROUND - Game 5 · Series tied 2-2".into()),
         }),
         standings,
     };
@@ -675,6 +676,7 @@ async fn preview_sport(matrix: &mut RGBMatrix, fonts: &Path) -> Result<(), Strin
                 score: Some(100),
             },
             our_side: HomeOrAway::Home,
+            playoff_note: None,
         }),
         standings: (1..=5)
             .map(|i| StandingsEntry {


### PR DESCRIPTION
Promotes the current `dev` work to `main`.

## Included

- **feat(sleep)**: schedule-driven sleep mode that blanks panels and pauses polling (#—).
- **fix(eink+sport)**: de-ghost refresh, off-season staleness handling, background + on-disk logo cache, playoff context ([#140](https://github.com/TheFinalJoke/ohmyoled/pull/140)).
- **feat(stock-chart)**: intraday 1D x-axis anchored to the regular trading session, plotting each close by its real time of day; a day in progress fills only the elapsed portion of the axis ([#141](https://github.com/TheFinalJoke/ohmyoled/pull/141)).

## Verification

All `cargo test --lib` + `cargo test --doc` pass and clippy is clean on the latest `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)