### PR TITLE
feat(sport): add show_offseason toggle + revamped off-season cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,12 +317,20 @@ sport:
   - run: true
     sport: golf
     tour: pga                      # pga | lpga | champions | korn | liv
+    show_offseason: true           # optional; default false
   - run: true
     sport: f1
+    show_offseason: true           # optional; default false
 ```
 
 Multiple entries rotate through together — basketball + hockey + golf +
 F1 in one display sequence is exactly the YAML above.
+
+Every sport entry accepts an optional **`show_offseason`** (bool, default
+`false`). When `false` the tile is skipped between seasons so the panel
+moves straight to the next module. Set it to `true` to draw an off-season
+card instead — the team crest + `OFFSEASON` for team sports, an
+`OFFSEASON` banner for golf, and the reigning-champion banner for F1.
 
 #### Team sports (basketball / baseball / football / hockey)
 
@@ -333,6 +341,7 @@ F1 in one display sequence is exactly the YAML above.
 | `team_logo.sport`      | enum   | Must match the entry's `sport` field.                                |
 | `team_logo.url`        | string | Logo image URL — fetched on first render and cached.                 |
 | `team_logo.sportsdb_leagueid`, `apisportsid`, `sportsdbid`, `sportsipyid` | int | Legacy IDs from the Python era. Kept for config compatibility; not all are still used by Rust. |
+| `show_offseason`       | bool   | Optional (default `false`). Draw a crest + `OFFSEASON` card off-season instead of skipping the slot. |
 
 Layout: scrolling home/away names on top, logos + score in the middle,
 scrolling division standings on the bottom. Middle-line color: green ⇐
@@ -346,7 +355,8 @@ Data source: ESPN's public scoreboard + standings endpoints
 ```yaml
 - run: true
   sport: golf
-  tour: pga    # optional; default: pga
+  tour: pga              # optional; default: pga
+  show_offseason: true   # optional; default: false
 ```
 
 | `tour` value | What it shows               |
@@ -357,20 +367,23 @@ Data source: ESPN's public scoreboard + standings endpoints
 | `korn`       | Korn Ferry Tour             |
 | `liv`        | LIV Golf                    |
 
-Top 5 only. Off-season shows a two-line placeholder. Score colors: red ⇐
-under par, white ⇐ even, yellow ⇐ over par. Data source: ESPN.
+Top 5 only. Off-season is skipped unless `show_offseason: true`, which
+draws an `OFFSEASON` card. Score colors: red ⇐ under par, white ⇐ even,
+yellow ⇐ over par. Data source: ESPN.
 
 #### Formula 1
 
 ```yaml
 - run: true
   sport: f1
+  show_offseason: true   # optional; default: false
 ```
 
-No extra fields. Header shows the next race + circuit + date; below it,
-a gold/silver/bronze podium of the top 3 in the constructor standings
-plus a scrolling tail with positions 4–10. Off-season shows a "season
-ended" placeholder.
+Header shows the next race + circuit + date; below it, a
+gold/silver/bronze podium of the top 3 in the constructor standings plus
+a scrolling tail with positions 4–10. Off-season is skipped unless
+`show_offseason: true`, which draws the reigning-champion banner (or an
+`OFFSEASON` card when standings are unavailable).
 
 Data source: <https://api.jolpi.ca> (Ergast-compatible). Two parallel
 requests per refresh: `current/next.json` + `current/driverStandings.json`.

--- a/examples/configs/ohmyoled.json
+++ b/examples/configs/ohmyoled.json
@@ -106,8 +106,8 @@
         "sportsipyid": 0
       }
     },
-    { "run": true, "sport": "golf", "tour": "pga" },
-    { "run": true, "sport": "f1" }
+    { "run": true, "sport": "golf", "tour": "pga", "show_offseason": true },
+    { "run": true, "sport": "f1", "show_offseason": true }
   ],
   "sleep": {
     "enabled": false,

--- a/examples/configs/ohmyoled.toml
+++ b/examples/configs/ohmyoled.toml
@@ -167,10 +167,12 @@ sportsipyid = 0
 run = true
 sport = "golf"
 tour = "pga"                  # pga | lpga | champions | korn | liv
+show_offseason = true         # draw an "OFFSEASON" card between events
 
 [[sport]]
 run = true
 sport = "f1"
+show_offseason = true         # draw the champion/"OFFSEASON" card off-season
 
 # ── Sleep mode — schedule-driven, opt-in ────────────────────────────
 # When enabled, blanks BOTH panels and pauses ALL API polling while the

--- a/examples/configs/ohmyoled.yaml
+++ b/examples/configs/ohmyoled.yaml
@@ -164,8 +164,10 @@ sport:
   - run: true
     sport: golf
     tour: pga                 # pga | lpga | champions | korn | liv
+    show_offseason: true      # draw an "OFFSEASON" card between events
   - run: true
     sport: f1
+    show_offseason: true      # draw the champion/"OFFSEASON" card off-season
 
 # ── Sleep mode — schedule-driven, opt-in ────────────────────────────
 # When enabled, blanks BOTH panels and pauses ALL API polling while the

--- a/examples/sport_render_check.rs
+++ b/examples/sport_render_check.rs
@@ -79,7 +79,7 @@ fn main() {
         ..data
     };
     ascii(
-        &m.draw_offseason(offseason.sport),
+        &m.draw_offseason(&offseason),
         "=== Offseason placeholder ===",
     );
 }

--- a/src/createjson/f1.rs
+++ b/src/createjson/f1.rs
@@ -3,10 +3,18 @@ use crate::createjson::tui::field::{FieldDef, FieldKind};
 /// TUI form schema. The constant `sport: "f1"` is injected in
 /// `form_module::section_to_value`. F1 needs no other config.
 pub fn fields() -> Vec<FieldDef> {
-    vec![FieldDef::new(
-        "cache_ttl_secs",
-        "Cache TTL (secs)",
-        super::CACHE_TTL_HELP,
-        FieldKind::CacheTtl,
-    )]
+    vec![
+        FieldDef::new(
+            "show_offseason",
+            "Show offseason",
+            "Draw the reigning-champion / \"OFFSEASON\" card between seasons instead of skipping the slot.",
+            FieldKind::Bool { default: false },
+        ),
+        FieldDef::new(
+            "cache_ttl_secs",
+            "Cache TTL (secs)",
+            super::CACHE_TTL_HELP,
+            FieldKind::CacheTtl,
+        ),
+    ]
 }

--- a/src/createjson/golf.rs
+++ b/src/createjson/golf.rs
@@ -20,6 +20,12 @@ pub fn fields() -> Vec<FieldDef> {
             },
         ),
         FieldDef::new(
+            "show_offseason",
+            "Show offseason",
+            "Draw an \"OFFSEASON\" card between tournaments instead of skipping the slot.",
+            FieldKind::Bool { default: false },
+        ),
+        FieldDef::new(
             "cache_ttl_secs",
             "Cache TTL (secs)",
             super::CACHE_TTL_HELP,

--- a/src/createjson/sport.rs
+++ b/src/createjson/sport.rs
@@ -28,6 +28,12 @@ pub fn fields() -> Vec<FieldDef> {
             FieldKind::ValueEnum,
         ),
         FieldDef::new(
+            "show_offseason",
+            "Show offseason",
+            "Draw a team-crest \"OFFSEASON\" card between seasons instead of skipping the slot.",
+            FieldKind::Bool { default: false },
+        ),
+        FieldDef::new(
             "cache_ttl_secs",
             "Cache TTL (secs)",
             super::CACHE_TTL_HELP,

--- a/src/lib/matrix/eink/f1.rs
+++ b/src/lib/matrix/eink/f1.rs
@@ -75,6 +75,9 @@ pub struct EinkF1Matrix {
     label: Font,
     countdown: Font,
     row: Font,
+    /// When `true`, the between-seasons slot renders the champion / "OFF-SEASON"
+    /// card; when `false` (the default) the tile yields its slot (no repaint).
+    show_offseason: bool,
 }
 
 impl EinkF1Matrix {
@@ -94,6 +97,7 @@ impl EinkF1Matrix {
             label: Font::load_ttf(&paths.body, scaled_px(22.0, h))?,
             countdown: Font::load_ttf(&paths.body, scaled_px(58.0, h))?,
             row: Font::load_ttf(&paths.body, scaled_px(24.0, h))?,
+            show_offseason: false,
         })
     }
 
@@ -101,6 +105,13 @@ impl EinkF1Matrix {
         tokio::task::spawn_blocking(move || Self::with_fonts(paths, dims))
             .await
             .map_err(|e| format!("font load task panicked: {e}"))?
+    }
+
+    /// Enable (or disable) the between-seasons card. Builder-style for the
+    /// registry.
+    pub fn with_offseason(mut self, show: bool) -> Self {
+        self.show_offseason = show;
+        self
     }
 
     /// Compose the F1 screen at `w × h`, sampling the countdown at `now`.
@@ -228,6 +239,10 @@ impl EinkRenderer for EinkF1Matrix {
     }
 
     async fn render(&mut self, display: &mut EinkDisplay, data: &F1Data) -> Result<(), RenderError> {
+        // Off-season + opted out: don't repaint — yield the slot.
+        if data.is_offseason() && !self.show_offseason {
+            return Ok(());
+        }
         let img = self.frame(data, Local::now(), display.width(), display.height());
         display.show(&img);
         tokio::time::sleep(self.cycle_duration()).await;

--- a/src/lib/matrix/eink/golf.rs
+++ b/src/lib/matrix/eink/golf.rs
@@ -57,6 +57,9 @@ pub struct EinkGolfMatrix {
     event: Font,
     row: Font,
     tour: GolfTour,
+    /// When `true`, off-season renders an "OFF-SEASON" card; when `false` (the
+    /// default) the tile yields its slot (no repaint).
+    show_offseason: bool,
 }
 
 impl EinkGolfMatrix {
@@ -75,6 +78,7 @@ impl EinkGolfMatrix {
             event: Font::load_ttf(&paths.body, scaled_px(32.0, h))?,
             row: Font::load_ttf(&paths.body, scaled_px(24.0, h))?,
             tour: GolfTour::Pga,
+            show_offseason: false,
         })
     }
 
@@ -87,6 +91,12 @@ impl EinkGolfMatrix {
     /// Set the tour shown in the header (defaults to PGA).
     pub fn with_tour(mut self, tour: GolfTour) -> Self {
         self.tour = tour;
+        self
+    }
+
+    /// Enable (or disable) the off-season card. Builder-style for the registry.
+    pub fn with_offseason(mut self, show: bool) -> Self {
+        self.show_offseason = show;
         self
     }
 
@@ -109,8 +119,20 @@ impl EinkGolfMatrix {
         let table_top = content_top + self.event.height() + m;
 
         if data.leaderboard.is_empty() {
-            let bx = cx - badge_width(&self.event, "NO TOURNAMENT") / 2;
-            badge(&mut img, &self.event, bx, hi / 2, "NO TOURNAMENT", fg, true);
+            // Off-season card: a centered "OFF-SEASON" badge over a quieter
+            // "NO ACTIVE TOURNAMENT" subtitle, below the tour/event header.
+            let label = "OFF-SEASON";
+            let bx = cx - badge_width(&self.event, label) / 2;
+            let by = (table_top + hi) / 2 - self.event.height();
+            badge(&mut img, &self.event, bx, by, label, fg, true);
+            crate::matrix::eink::layout::center_text(
+                &mut img,
+                &self.row,
+                cx,
+                by + self.event.height() + m + self.row.ascent(),
+                fg,
+                "NO ACTIVE TOURNAMENT",
+            );
             return img;
         }
 
@@ -147,6 +169,10 @@ impl EinkRenderer for EinkGolfMatrix {
     }
 
     async fn render(&mut self, display: &mut EinkDisplay, data: &GolfData) -> Result<(), RenderError> {
+        // Off-season + opted out: don't repaint — yield the slot.
+        if data.is_offseason() && !self.show_offseason {
+            return Ok(());
+        }
         let img = self.frame(data, display.width(), display.height());
         display.show(&img);
         tokio::time::sleep(self.cycle_duration()).await;

--- a/src/lib/matrix/eink/sport.rs
+++ b/src/lib/matrix/eink/sport.rs
@@ -79,6 +79,13 @@ pub struct EinkSportMatrix {
     /// Team names with a logo fetch currently in flight, so at most one task is
     /// spawned per team even while the fetch is still pending.
     logo_inflight: Arc<Mutex<HashSet<String>>>,
+    /// When `true`, off-season renders a crest + "OFF-SEASON" card; when `false`
+    /// (the default) the tile yields its slot (no repaint) so the panel keeps
+    /// the previous module's content.
+    show_offseason: bool,
+    /// Configured team badge URL, fetched for the off-season crest (off-season
+    /// payloads carry no per-side `logo_url`).
+    offseason_logo_url: Option<String>,
 }
 
 impl EinkSportMatrix {
@@ -101,7 +108,42 @@ impl EinkSportMatrix {
             row: Font::load_ttf(&paths.body, scaled_px(22.0, h))?,
             logo_cache: Arc::new(Mutex::new(HashMap::new())),
             logo_inflight: Arc::new(Mutex::new(HashSet::new())),
+            show_offseason: false,
+            offseason_logo_url: None,
         })
+    }
+
+    /// Enable (or disable) the off-season card and supply the team badge URL it
+    /// draws. Builder-style so the registry can chain it onto `new_async`.
+    pub fn with_offseason(mut self, show: bool, logo_url: Option<String>) -> Self {
+        self.show_offseason = show;
+        self.offseason_logo_url = logo_url;
+        self
+    }
+
+    /// Background-fetch the configured badge for the off-season crest, keyed by
+    /// team name (the same cache `draw_crest`/the card read). Returns
+    /// immediately — never blocks the render path.
+    fn prefetch_offseason_logo(&self, data: &SportData) {
+        let Some(url) = self.offseason_logo_url.clone() else { return };
+        let name = data.team_name.clone();
+        if self.logo_cache.lock().unwrap().contains_key(&name) {
+            return;
+        }
+        if !self.logo_inflight.lock().unwrap().insert(name.clone()) {
+            return;
+        }
+        let cache = Arc::clone(&self.logo_cache);
+        let inflight = Arc::clone(&self.logo_inflight);
+        tokio::spawn(async move {
+            match fetch_logo(&url).await {
+                Ok(logo) => {
+                    cache.lock().unwrap().insert(name.clone(), logo);
+                }
+                Err(e) => log::warn!("eink sport: offseason logo fetch failed for {name} ({url}): {e}"),
+            }
+            inflight.lock().unwrap().remove(&name);
+        });
     }
 
     /// Kick off a background fetch of a team's logo into the shared cache.
@@ -153,13 +195,14 @@ impl EinkSportMatrix {
 
         match data.current_game(Local::now()) {
             Some(game) => self.draw_scoreboard(&mut img, game, content_top, standings_top, fg),
+            None if data.standings.is_empty() => {
+                self.draw_offseason_card(&mut img, data, content_top, standings_top, fg);
+            }
             None => {
-                let label = if data.standings.is_empty() {
-                    format!("{} OFF-SEASON", data.sport.display_name())
-                } else {
-                    "NO UPCOMING GAME".to_string()
-                };
-                // The abbreviation font is large but still fits these labels.
+                // Standings present but no current game — a between-games lull,
+                // not the off-season. Keep the simple label; the table renders
+                // below.
+                let label = "NO UPCOMING GAME".to_string();
                 let bx = cx - badge_width(&self.abbr, &label) / 2;
                 let by = (content_top + standings_top) / 2 - self.abbr.height() / 2;
                 badge(&mut img, &self.abbr, bx, by, &label, fg, true);
@@ -228,6 +271,39 @@ impl EinkSportMatrix {
                 center_text(img, &self.status, cx, score_cy + self.status.height(), fg, &time);
             }
         }
+    }
+
+    /// Off-season card: the team crest (when its badge has been fetched)
+    /// centered above the team name and an "OFF-SEASON" badge. With no crest yet
+    /// (cold cache) it gracefully degrades to name + badge.
+    fn draw_offseason_card(&self, img: &mut RgbImage, data: &SportData, top: i32, bottom: i32, fg: Color) {
+        let wi = img.width() as i32;
+        let m = margin(img.width());
+        let cx = wi / 2;
+        let band_h = bottom - top;
+        let cy = top + band_h / 2;
+
+        // Crest (if fetched) centered in the upper part of the band.
+        let cached = self.logo_cache.lock().unwrap().get(&data.team_name).cloned();
+        let crest_w = (wi / 5).min(band_h * 40 / 100);
+        let name_y = if let Some(logo) = cached {
+            let bx = cx - crest_w / 2;
+            let by = cy - band_h / 4 - crest_w / 2;
+            draw_logo_silhouette(img, &logo, bx, by, crest_w, fg);
+            by + crest_w + m
+        } else {
+            top + m
+        };
+
+        // Team name under the crest.
+        let name = fit_text(&self.name, &data.team_name.to_uppercase(), wi - 2 * m);
+        center_text(img, &self.name, cx, name_y + self.name.ascent(), fg, &name);
+
+        // "OFF-SEASON" badge anchored toward the bottom of the band.
+        let label = "OFF-SEASON";
+        let bx = cx - badge_width(&self.status, label) / 2;
+        let by = (name_y + self.name.height() + bottom) / 2 - self.status.height() / 2;
+        badge(img, &self.status, bx, by, label, fg, true);
     }
 
     /// Draw a team crest into the `box_w` square at `(cx - box_w/2, box_top)`:
@@ -308,12 +384,20 @@ impl EinkRenderer for EinkSportMatrix {
     }
 
     async fn render(&mut self, display: &mut EinkDisplay, data: &SportData) -> Result<(), RenderError> {
+        // Off-season + opted out: don't repaint. Leave the previous module's
+        // content on the panel and let the scheduler advance.
+        if data.is_offseason() && !self.show_offseason {
+            return Ok(());
+        }
         // Kick off logo fetches in the background — never block the panel on
         // the network. `frame` draws the abbreviation box until a logo lands.
-        // Only for a current game (off-season has no scoreboard to fill).
+        // A current game prefetches both sides' crests; the off-season card
+        // prefetches the configured team badge instead.
         if let Some(game) = data.current_game(Local::now()) {
             self.prefetch_logo(&game.home);
             self.prefetch_logo(&game.away);
+        } else if data.is_offseason() {
+            self.prefetch_offseason_logo(data);
         }
         let img = self.frame(data, display.width(), display.height());
         display.show(&img);

--- a/src/lib/matrix/f1.rs
+++ b/src/lib/matrix/f1.rs
@@ -15,7 +15,8 @@
 //! ```
 //!
 //! Podium colors: gold / silver / bronze. The header band is F1 red.
-//! Off-season shows a "season ended" placeholder for ~20s.
+//! Off-season is skipped by default; set `show_offseason: true` to draw the
+//! reigning-champion banner (or an "OFFSEASON" card) for ~20s between seasons.
 //!
 //! # Config
 //!
@@ -26,6 +27,7 @@
 //! sport:
 //!   - run: true
 //!     sport: f1
+//!     show_offseason: false    # true ⇒ draw the champion/"OFFSEASON" card
 //! ```
 //!
 //! # Data source
@@ -147,6 +149,10 @@ impl Default for F1Fonts {
 
 pub struct F1Matrix {
     body_font: Font,
+    /// When `true`, the between-seasons slot shows the champion banner (or an
+    /// "OFFSEASON" card when standings are unavailable); when `false` (the
+    /// default) the slot is skipped.
+    show_offseason: bool,
 }
 
 impl F1Matrix {
@@ -159,13 +165,23 @@ impl F1Matrix {
     }
 
     pub fn with_fonts(paths: F1Fonts) -> Result<Self, String> {
-        Ok(Self { body_font: Font::load_ttf(&paths.body, 8.0)? })
+        Ok(Self {
+            body_font: Font::load_ttf(&paths.body, 8.0)?,
+            show_offseason: false,
+        })
     }
 
     pub async fn with_fonts_async(paths: F1Fonts) -> Result<Self, String> {
         tokio::task::spawn_blocking(move || Self::with_fonts(paths))
             .await
             .map_err(|e| format!("font load task panicked: {e}"))?
+    }
+
+    /// Enable (or disable) the between-seasons card. Builder-style for the
+    /// registry.
+    pub fn with_offseason(mut self, show: bool) -> Self {
+        self.show_offseason = show;
+        self
     }
 }
 
@@ -190,11 +206,15 @@ impl Renderer for F1Matrix {
     async fn render(&mut self, matrix: &mut RGBMatrix, data: &F1Data) -> Result<(), RenderError> {
         matrix.clear();
         if data.is_offseason() {
-            // Between seasons. If we have standings, the leader is the
-            // outgoing world champion — show a static banner. Otherwise
-            // skip this slot entirely so the scheduler advances.
-            if let Some(champ) = data.standings.first() {
-                let img = self.draw_champion(data, champ);
+            // Between seasons. Opt-in only: if we have standings, the leader is
+            // the outgoing world champion — show a static banner; otherwise show
+            // a plain "OFFSEASON" card. With the flag off, skip the slot so the
+            // scheduler advances.
+            if self.show_offseason {
+                let img = match data.standings.first() {
+                    Some(champ) => self.draw_champion(data, champ),
+                    None => self.draw_offseason(data),
+                };
                 matrix.set_image(&img, 0, 0);
                 tokio::time::sleep(Duration::from_secs(20)).await;
                 matrix.clear();
@@ -436,6 +456,30 @@ impl F1Matrix {
 
         img
     }
+
+    /// Plain between-seasons card for the rare case where no standings are
+    /// available to build a champion banner:
+    ///
+    /// ```text
+    ///   F1 2026
+    ///   OFFSEASON
+    ///   Back in March
+    /// ```
+    pub fn draw_offseason(&self, data: &F1Data) -> RgbImage {
+        let mut img = RgbImage::new(PANEL_W, PANEL_H);
+        let font = &self.body_font;
+
+        let bl0 = top_to_baseline(2, font.ascent());
+        draw_text(&mut img, font, 2, bl0, F1_RED, &format!("F1 {}", data.season));
+
+        let bl1 = top_to_baseline(12, font.ascent());
+        draw_text(&mut img, font, 2, bl1, GOLD, "OFFSEASON");
+
+        let bl2 = top_to_baseline(22, font.ascent());
+        draw_text(&mut img, font, 2, bl2, Color::new(160, 160, 160), "Back in March");
+
+        img
+    }
 }
 
 fn top_to_baseline(top_y: i32, ascent: i32) -> i32 {
@@ -493,6 +537,17 @@ mod tests {
         assert!(data.is_offseason());
         let champ = data.standings.first().unwrap();
         let img = m.draw_champion(&data, champ);
+        assert!(img.pixels().filter(|p| p.0 != [0, 0, 0]).count() > 20);
+    }
+
+    #[test]
+    fn offseason_card_renders_without_standings() {
+        // No next race and no standings → the plain "OFFSEASON" fallback card.
+        let m = F1Matrix::with_fonts(repo_fonts()).expect("fonts");
+        let data = sample(false, 0);
+        assert!(data.is_offseason());
+        assert!(data.standings.is_empty());
+        let img = m.draw_offseason(&data);
         assert!(img.pixels().filter(|p| p.0 != [0, 0, 0]).count() > 20);
     }
 

--- a/src/lib/matrix/golf.rs
+++ b/src/lib/matrix/golf.rs
@@ -22,7 +22,8 @@
 //! statuses like "Round 4 In Progress".
 //!
 //! Score colors: red ⇐ under par, white ⇐ even, yellow ⇐ over par.
-//! Off-season shows a two-line placeholder for ~20s.
+//! Off-season is skipped by default; set `show_offseason: true` to draw an
+//! "OFFSEASON" card (~20s) between tournaments.
 //!
 //! # Config
 //!
@@ -34,7 +35,8 @@
 //! sport:
 //!   - run: true
 //!     sport: golf
-//!     tour: pga          # pga | lpga | champions | korn | liv
+//!     tour: pga                # pga | lpga | champions | korn | liv
+//!     show_offseason: false    # true ⇒ draw an "OFFSEASON" card between events
 //! ```
 //!
 //! # Data source
@@ -60,6 +62,11 @@ const SCROLL_FRAMES: u32 = 700;
 const SCROLL_TICK: Duration = Duration::from_millis(50);
 const FIRST_FRAME_DWELL: Duration = Duration::from_secs(3);
 const FINAL_DWELL: Duration = Duration::from_secs(5);
+/// How long the static off-season card stays up before yielding the slot.
+const OFFSEASON_DWELL: Duration = Duration::from_secs(20);
+
+/// Amber accent reused for the tour code on the off-season card.
+const TOUR_AMBER: Color = Color { r: 247, g: 200, b: 0 };
 
 /// Max leaderboard entries shown in the cycling roll.
 const LEADERBOARD_MAX: usize = 15;
@@ -99,6 +106,9 @@ impl Default for GolfFonts {
 
 pub struct GolfMatrix {
     body_font: Font,
+    /// When `true`, off-season (no active tournament) renders an "OFFSEASON"
+    /// card; when `false` (the default) the slot is skipped.
+    show_offseason: bool,
 }
 
 impl GolfMatrix {
@@ -111,13 +121,22 @@ impl GolfMatrix {
     }
 
     pub fn with_fonts(paths: GolfFonts) -> Result<Self, String> {
-        Ok(Self { body_font: Font::load_ttf(&paths.body, 8.0)? })
+        Ok(Self {
+            body_font: Font::load_ttf(&paths.body, 8.0)?,
+            show_offseason: false,
+        })
     }
 
     pub async fn with_fonts_async(paths: GolfFonts) -> Result<Self, String> {
         tokio::task::spawn_blocking(move || Self::with_fonts(paths))
             .await
             .map_err(|e| format!("font load task panicked: {e}"))?
+    }
+
+    /// Enable (or disable) the off-season card. Builder-style for the registry.
+    pub fn with_offseason(mut self, show: bool) -> Self {
+        self.show_offseason = show;
+        self
     }
 }
 
@@ -142,8 +161,14 @@ impl Renderer for GolfMatrix {
     async fn render(&mut self, matrix: &mut RGBMatrix, data: &GolfData) -> Result<(), RenderError> {
         matrix.clear();
         if data.is_offseason() {
-            // No active tournament leaderboard. We don't fetch a "previous
-            // event winner" from ESPN, so skip this slot entirely.
+            // No active tournament leaderboard. Either draw the opt-in
+            // "OFFSEASON" card or skip the slot so the scheduler advances.
+            if self.show_offseason {
+                let img = self.draw_offseason(data);
+                matrix.set_image(&img, 0, 0);
+                tokio::time::sleep(OFFSEASON_DWELL).await;
+                matrix.clear();
+            }
             return Ok(());
         }
 
@@ -321,13 +346,25 @@ impl GolfMatrix {
         );
     }
 
+    /// Off-season card shown between tournaments: the tour code (amber) over an
+    /// "OFFSEASON" banner and a "No events" subtitle, instead of a blank slot.
+    ///
+    /// ```text
+    ///   ┌──────────────────┐
+    ///   │ PGA              │  row 1   amber tour code
+    ///   │ OFFSEASON        │  row 12  white banner
+    ///   │ No events        │  row 22  grey subtitle
+    ///   └──────────────────┘
+    /// ```
     pub fn draw_offseason(&self, data: &GolfData) -> RgbImage {
         let mut img = RgbImage::new(PANEL_W, PANEL_H);
         let font = &self.body_font;
-        let bl0 = top_to_baseline(8, font.ascent());
-        let bl1 = top_to_baseline(18, font.ascent());
-        draw_text(&mut img, font, 2, bl0, Color::WHITE, data.tour.display_name());
-        draw_text(&mut img, font, 2, bl1, Color::WHITE, "No event");
+        let bl0 = top_to_baseline(1, font.ascent());
+        let bl1 = top_to_baseline(12, font.ascent());
+        let bl2 = top_to_baseline(22, font.ascent());
+        draw_text(&mut img, font, 2, bl0, TOUR_AMBER, data.tour.display_name());
+        draw_text(&mut img, font, 2, bl1, Color::WHITE, "OFFSEASON");
+        draw_text(&mut img, font, 2, bl2, Color::new(156, 163, 173), "No events");
         img
     }
 }

--- a/src/lib/matrix/sport.rs
+++ b/src/lib/matrix/sport.rs
@@ -17,7 +17,8 @@
 //! of the renderer.
 //!
 //! Middle-line color: green ⇐ home winning, red ⇐ home losing, white ⇐ tied
-//! or scheduled. Off-season shows a two-line "season ended" placeholder.
+//! or scheduled. Off-season is skipped by default; set `show_offseason: true`
+//! to draw a team-crest "OFFSEASON" card instead.
 //!
 //! # Config
 //!
@@ -30,6 +31,7 @@
 //! sport:
 //!   - run: true
 //!     sport: basketball        # basketball | baseball | football | hockey
+//!     show_offseason: false    # true ⇒ draw a crest "OFFSEASON" card off-season
 //!     team_logo:
 //!       name: "Boston Celtics"
 //!       shorthand: BOS
@@ -52,9 +54,7 @@
 //! once via `/teams/{abbreviation}` and cached for the process lifetime.
 
 use crate::api::http::shared_client;
-use crate::api::sport::model::{
-    GameStatus, HomeOrAway, NextGame, SportData, SportKind, TeamSide,
-};
+use crate::api::sport::model::{GameStatus, HomeOrAway, NextGame, SportData, TeamSide};
 use crate::matrix::cells::draw_text_in_window;
 use crate::matrix::error::RenderError;
 use crate::matrix::renderer::Renderer;
@@ -76,6 +76,11 @@ const SCROLL_FRAMES: u32 = 600;
 const SCROLL_TICK: Duration = Duration::from_millis(50);
 const FIRST_FRAME_DWELL: Duration = Duration::from_secs(3);
 const FINAL_DWELL: Duration = Duration::from_secs(15);
+/// How long the static off-season card stays up before yielding the slot.
+const OFFSEASON_DWELL: Duration = Duration::from_secs(20);
+
+/// Amber accent for the "OFFSEASON" banner on the off-season card.
+const OFFSEASON_AMBER: Color = Color { r: 247, g: 200, b: 0 };
 
 const STANDINGS_COLOR: Color = Color { r: 156, g: 163, b: 173 };
 
@@ -98,6 +103,13 @@ pub struct SportMatrix {
     body_font: Font,
     big_font: Font,
     logo_cache: HashMap<String, RgbImage>,
+    /// When `true`, off-season renders a team-crest + "OFFSEASON" card; when
+    /// `false` (the default) the slot is skipped so the scheduler advances.
+    show_offseason: bool,
+    /// Badge URL to fetch for the off-season card. Off-season payloads carry no
+    /// game (so no per-side `logo_url`), so the configured team badge is plumbed
+    /// in here and fetched on demand into [`Self::logo_cache`].
+    offseason_logo_url: Option<String>,
 }
 
 impl SportMatrix {
@@ -114,6 +126,8 @@ impl SportMatrix {
             body_font: Font::load_ttf(&paths.body, 8.0)?,
             big_font: Font::load_ttf(&paths.big, 14.0)?,
             logo_cache: HashMap::new(),
+            show_offseason: false,
+            offseason_logo_url: None,
         })
     }
 
@@ -121,6 +135,29 @@ impl SportMatrix {
         tokio::task::spawn_blocking(move || Self::with_fonts(paths))
             .await
             .map_err(|e| format!("font load task panicked: {e}"))?
+    }
+
+    /// Enable (or disable) the off-season card and supply the team badge URL it
+    /// draws. Builder-style so the registry can chain it onto `new_async`.
+    pub fn with_offseason(mut self, show: bool, logo_url: Option<String>) -> Self {
+        self.show_offseason = show;
+        self.offseason_logo_url = logo_url;
+        self
+    }
+
+    /// Fetch + cache the configured badge for the off-season card. Keyed by team
+    /// name so [`Self::draw_offseason`] can look it up; a miss just draws text.
+    async fn ensure_offseason_logo(&mut self, data: &SportData) {
+        if self.logo_cache.contains_key(&data.team_name) {
+            return;
+        }
+        let Some(url) = self.offseason_logo_url.clone() else { return };
+        match fetch_logo(&url).await {
+            Ok(logo) => {
+                self.logo_cache.insert(data.team_name.clone(), logo);
+            }
+            Err(e) => log::warn!("sport: offseason logo fetch failed ({url}): {e}"),
+        }
     }
 
     /// Fetch + decode + resize + cache a team's logo. Idempotent.
@@ -163,9 +200,16 @@ impl Renderer for SportMatrix {
         matrix.clear();
 
         if data.is_offseason() {
-            // No upcoming game and no standings to display. We don't fetch
-            // a prior-season champion, so skip this slot entirely — the
-            // scheduler will move to the next module.
+            // No upcoming game and no standings to display. Either draw the
+            // opt-in off-season card (team crest + "OFFSEASON") or skip the
+            // slot so the scheduler moves to the next module.
+            if self.show_offseason {
+                self.ensure_offseason_logo(data).await;
+                let img = self.draw_offseason(data);
+                matrix.set_image(&img, 0, 0);
+                tokio::time::sleep(OFFSEASON_DWELL).await;
+                matrix.clear();
+            }
             return Ok(());
         }
 
@@ -206,14 +250,57 @@ impl SportMatrix {
         img
     }
 
-    /// Render the offseason placeholder ("NBA / Offseason"). Public for
-    /// examples and visual-regression checks.
-    pub fn draw_offseason(&self, sport: SportKind) -> RgbImage {
+    /// Render the off-season card: the team crest (top-left, when its badge has
+    /// been fetched) with the team name beside it, an amber "OFFSEASON" banner,
+    /// and a "Returns soon" subtitle. The crest is looked up from `logo_cache`
+    /// by team name — a miss (e.g. in unit tests with no network) just leaves
+    /// the slot blank and renders the text. Public for examples + visual checks.
+    ///
+    /// ```text
+    ///   ┌──────────────────┐
+    ///   │ ▢LOGO▢  Lakers   │  rows 0..15  crest + team name
+    ///   │ OFFSEASON        │  rows 16..31 amber banner (big font)
+    ///   └──────────────────┘
+    /// ```
+    pub fn draw_offseason(&self, data: &SportData) -> RgbImage {
         let mut img = RgbImage::new(PANEL_W, PANEL_H);
-        let baseline_1 = top_to_baseline(2, self.big_font.ascent());
-        let baseline_2 = top_to_baseline(17, self.big_font.ascent());
-        draw_text(&mut img, &self.big_font, 4, baseline_1, Color::WHITE, sport.display_name());
-        draw_text(&mut img, &self.big_font, 4, baseline_2, Color::WHITE, "Offseason");
+        let font = &self.body_font;
+
+        // Crest top-left when fetched; otherwise the text shifts to the edge.
+        let has_logo = self.logo_cache.contains_key(&data.team_name);
+        if let Some(logo) = self.logo_cache.get(&data.team_name) {
+            paste(&mut img, logo, 0, 0);
+        }
+        let text_x = if has_logo { LOGO_SIZE as i32 + 2 } else { 2 };
+
+        // Team name (clipped to the right of the crest) on the top band, with a
+        // small grey "off season" hint beneath it.
+        let name_baseline = top_to_baseline(2, font.ascent());
+        draw_text_in_window(
+            &mut img,
+            font,
+            text_x,
+            name_baseline,
+            Color::WHITE,
+            &data.team_name,
+            text_x,
+            PANEL_W as i32,
+        );
+        let hint_baseline = top_to_baseline(9, font.ascent());
+        draw_text_in_window(
+            &mut img,
+            font,
+            text_x,
+            hint_baseline,
+            STANDINGS_COLOR,
+            "Returns soon",
+            text_x,
+            PANEL_W as i32,
+        );
+
+        // Bold amber "OFFSEASON" banner across the bottom band.
+        let banner_baseline = top_to_baseline(16, self.big_font.ascent());
+        draw_text(&mut img, &self.big_font, 2, banner_baseline, OFFSEASON_AMBER, "OFFSEASON");
         img
     }
 
@@ -460,7 +547,7 @@ fn decode_and_resize(bytes: &[u8]) -> Result<RgbImage, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::sport::model::{SportApiSource, StandingsEntry};
+    use crate::api::sport::model::{SportApiSource, SportKind, StandingsEntry};
     use std::path::PathBuf;
 
     fn repo_fonts() -> SportFonts {
@@ -523,11 +610,13 @@ mod tests {
     }
 
     #[test]
-    fn offseason_renders_two_line_placeholder() {
+    fn offseason_renders_card_text() {
         let m = SportMatrix::with_fonts(repo_fonts()).expect("fonts load");
         let data = make_data(false, false, GameStatus::Scheduled);
         assert!(data.is_offseason());
-        let img = m.draw_offseason(data.sport);
+        // No badge fetched in tests — the card still renders the team name +
+        // "OFFSEASON" banner text.
+        let img = m.draw_offseason(&data);
         let lit = img.pixels().filter(|p| p.0 != [0, 0, 0]).count();
         assert!(lit > 20, "offseason frame should have visible text, got {lit}");
     }

--- a/src/lib/modules/registry.rs
+++ b/src/lib/modules/registry.rs
@@ -298,6 +298,11 @@ pub enum SportSection {
     Basketball {
         run: bool,
         team_logo: crate::teams::Logo,
+        /// Render an off-season card (team crest + "OFFSEASON") instead of
+        /// skipping the slot when there's no current game or standings.
+        /// Defaults to `false` so existing configs are unchanged.
+        #[serde(default)]
+        show_offseason: bool,
         #[serde(default)]
         cache_ttl_secs: Option<u64>,
     },
@@ -305,11 +310,15 @@ pub enum SportSection {
         run: bool,
         team_logo: crate::teams::Logo,
         #[serde(default)]
+        show_offseason: bool,
+        #[serde(default)]
         cache_ttl_secs: Option<u64>,
     },
     Football {
         run: bool,
         team_logo: crate::teams::Logo,
+        #[serde(default)]
+        show_offseason: bool,
         #[serde(default)]
         cache_ttl_secs: Option<u64>,
     },
@@ -317,17 +326,27 @@ pub enum SportSection {
         run: bool,
         team_logo: crate::teams::Logo,
         #[serde(default)]
+        show_offseason: bool,
+        #[serde(default)]
         cache_ttl_secs: Option<u64>,
     },
     Golf {
         run: bool,
         #[serde(default = "default_golf_tour")]
         tour: GolfTour,
+        /// Show an "OFFSEASON" card between tournaments instead of skipping
+        /// the slot. Defaults to `false`.
+        #[serde(default)]
+        show_offseason: bool,
         #[serde(default)]
         cache_ttl_secs: Option<u64>,
     },
     F1 {
         run: bool,
+        /// Show the reigning-champion / "OFFSEASON" card between seasons
+        /// instead of skipping the slot. Defaults to `false`.
+        #[serde(default)]
+        show_offseason: bool,
         #[serde(default)]
         cache_ttl_secs: Option<u64>,
     },
@@ -353,6 +372,17 @@ impl SportSection {
             | Self::Hockey { cache_ttl_secs, .. }
             | Self::Golf { cache_ttl_secs, .. }
             | Self::F1 { cache_ttl_secs, .. } => *cache_ttl_secs,
+        }
+    }
+
+    fn show_offseason(&self) -> bool {
+        match self {
+            Self::Basketball { show_offseason, .. }
+            | Self::Baseball { show_offseason, .. }
+            | Self::Football { show_offseason, .. }
+            | Self::Hockey { show_offseason, .. }
+            | Self::Golf { show_offseason, .. }
+            | Self::F1 { show_offseason, .. } => *show_offseason,
         }
     }
 }
@@ -631,31 +661,34 @@ async fn build_stock(s: &StockSection) -> Result<Box<dyn DynModule>, String> {
 
 async fn build_sport(s: &SportSection) -> Result<Box<dyn DynModule>, String> {
     let ttl = s.cache_ttl_secs();
+    let show_offseason = s.show_offseason();
     match s {
         SportSection::Basketball { team_logo, .. } => {
-            build_team_sport(SportKind::Basketball, team_logo, ttl).await
+            build_team_sport(SportKind::Basketball, team_logo, show_offseason, ttl).await
         }
         SportSection::Baseball { team_logo, .. } => {
-            build_team_sport(SportKind::Baseball, team_logo, ttl).await
+            build_team_sport(SportKind::Baseball, team_logo, show_offseason, ttl).await
         }
         SportSection::Football { team_logo, .. } => {
-            build_team_sport(SportKind::Football, team_logo, ttl).await
+            build_team_sport(SportKind::Football, team_logo, show_offseason, ttl).await
         }
         SportSection::Hockey { team_logo, .. } => {
-            build_team_sport(SportKind::Hockey, team_logo, ttl).await
+            build_team_sport(SportKind::Hockey, team_logo, show_offseason, ttl).await
         }
         SportSection::Golf { tour, .. } => {
             let collector = GolfCollector::from_espn(*tour);
             let renderer = GolfMatrix::new_async()
                 .await
-                .map_err(|e| format!("golf fonts: {e}"))?;
+                .map_err(|e| format!("golf fonts: {e}"))?
+                .with_offseason(show_offseason);
             Ok(module_with_ttl(collector, renderer, ttl))
         }
         SportSection::F1 { .. } => {
             let collector = F1Collector::from_jolpica();
             let renderer = F1Matrix::new_async()
                 .await
-                .map_err(|e| format!("f1 fonts: {e}"))?;
+                .map_err(|e| format!("f1 fonts: {e}"))?
+                .with_offseason(show_offseason);
             Ok(module_with_ttl(collector, renderer, ttl))
         }
     }
@@ -756,6 +789,7 @@ async fn build_pihole(s: &PiholeSection) -> Result<Box<dyn DynModule>, String> {
 async fn build_team_sport(
     kind: SportKind,
     team_logo: &crate::teams::Logo,
+    show_offseason: bool,
     cache_ttl_secs: Option<u64>,
 ) -> Result<Box<dyn DynModule>, String> {
     let collector = SportCollector::from_espn(EspnConfig {
@@ -763,9 +797,13 @@ async fn build_team_sport(
         team_name: team_logo.name.clone(),
         team_abbreviation: team_logo.shorthand.clone(),
     });
+    // The off-season card draws the team crest, but off-season payloads carry
+    // no game (hence no per-side logo URL), so pass the configured badge URL
+    // straight through for the renderer to fetch on demand.
     let renderer = SportMatrix::new_async()
         .await
-        .map_err(|e| format!("sport fonts: {e}"))?;
+        .map_err(|e| format!("sport fonts: {e}"))?
+        .with_offseason(show_offseason, Some(team_logo.url.clone()));
     Ok(module_with_ttl(collector, renderer, cache_ttl_secs))
 }
 
@@ -1042,32 +1080,35 @@ pub async fn build_eink(cfg: &RegistryConfig, dims: (u32, u32)) -> Vec<Box<dyn D
 /// the LED [`build_sport`].
 async fn build_eink_sport(s: &SportSection, dims: (u32, u32)) -> Result<Box<dyn DynEinkModule>, String> {
     let ttl = s.cache_ttl_secs();
+    let show_offseason = s.show_offseason();
     match s {
         SportSection::Basketball { team_logo, .. } => {
-            build_eink_team_sport(SportKind::Basketball, team_logo, ttl, dims).await
+            build_eink_team_sport(SportKind::Basketball, team_logo, show_offseason, ttl, dims).await
         }
         SportSection::Baseball { team_logo, .. } => {
-            build_eink_team_sport(SportKind::Baseball, team_logo, ttl, dims).await
+            build_eink_team_sport(SportKind::Baseball, team_logo, show_offseason, ttl, dims).await
         }
         SportSection::Football { team_logo, .. } => {
-            build_eink_team_sport(SportKind::Football, team_logo, ttl, dims).await
+            build_eink_team_sport(SportKind::Football, team_logo, show_offseason, ttl, dims).await
         }
         SportSection::Hockey { team_logo, .. } => {
-            build_eink_team_sport(SportKind::Hockey, team_logo, ttl, dims).await
+            build_eink_team_sport(SportKind::Hockey, team_logo, show_offseason, ttl, dims).await
         }
         SportSection::Golf { tour, .. } => {
             let collector = GolfCollector::from_espn(*tour);
             let renderer = EinkGolfMatrix::new_async(dims)
                 .await
                 .map_err(|e| format!("eink golf fonts: {e}"))?
-                .with_tour(*tour);
+                .with_tour(*tour)
+                .with_offseason(show_offseason);
             Ok(eink_module_with_ttl(collector, renderer, ttl))
         }
         SportSection::F1 { .. } => {
             let collector = F1Collector::from_jolpica();
             let renderer = EinkF1Matrix::new_async(dims)
                 .await
-                .map_err(|e| format!("eink f1 fonts: {e}"))?;
+                .map_err(|e| format!("eink f1 fonts: {e}"))?
+                .with_offseason(show_offseason);
             Ok(eink_module_with_ttl(collector, renderer, ttl))
         }
     }
@@ -1076,6 +1117,7 @@ async fn build_eink_sport(s: &SportSection, dims: (u32, u32)) -> Result<Box<dyn 
 async fn build_eink_team_sport(
     kind: SportKind,
     team_logo: &crate::teams::Logo,
+    show_offseason: bool,
     cache_ttl_secs: Option<u64>,
     dims: (u32, u32),
 ) -> Result<Box<dyn DynEinkModule>, String> {
@@ -1086,7 +1128,8 @@ async fn build_eink_team_sport(
     });
     let renderer = EinkSportMatrix::new_async(dims)
         .await
-        .map_err(|e| format!("eink sport fonts: {e}"))?;
+        .map_err(|e| format!("eink sport fonts: {e}"))?
+        .with_offseason(show_offseason, Some(team_logo.url.clone()));
     Ok(eink_module_with_ttl(collector, renderer, cache_ttl_secs))
 }
 

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -668,11 +668,14 @@ async fn preview_stock_chart(matrix: &mut RGBMatrix, fonts: &Path) -> Result<(),
 }
 
 async fn preview_sport(matrix: &mut RGBMatrix, fonts: &Path) -> Result<(), String> {
+    // Enable the off-season card with a real badge URL so the crest renders
+    // live (degrades to text if the preview host is offline).
     let mut r = SportMatrix::with_fonts_async(SportFonts {
         body: fonts.join("04B_03B_.TTF"),
         big: fonts.join("04b24.otf"),
     })
-    .await?;
+    .await?
+    .with_offseason(true, Some("https://a.espncdn.com/i/teamlogos/nba/500/bos.png".into()));
     let data = SportData {
         api: SportApiSource::Espn,
         sport: SportKind::Basketball,
@@ -703,8 +706,18 @@ async fn preview_sport(matrix: &mut RGBMatrix, fonts: &Path) -> Result<(), Strin
             })
             .collect(),
     };
+    // Off-season variant: no current game + no standings → the crest card.
+    let offseason = SportData {
+        next_game: None,
+        standings: vec![],
+        ..data.clone()
+    };
+    // Alternate so the scoreboard and the off-season card both get airtime.
+    let mut toggle = false;
     loop {
-        r.render(matrix, &data).await.map_err(|e| e.to_string())?;
+        let d = if toggle { &offseason } else { &data };
+        toggle = !toggle;
+        r.render(matrix, d).await.map_err(|e| e.to_string())?;
     }
 }
 
@@ -712,7 +725,8 @@ async fn preview_golf(matrix: &mut RGBMatrix, fonts: &Path) -> Result<(), String
     let mut r = GolfMatrix::with_fonts_async(GolfFonts {
         body: fonts.join("04B_03B_.TTF"),
     })
-    .await?;
+    .await?
+    .with_offseason(true);
     let data = GolfData {
         tour: GolfTour::Pga,
         event_name: "Masters Tournament".into(),
@@ -725,8 +739,13 @@ async fn preview_golf(matrix: &mut RGBMatrix, fonts: &Path) -> Result<(), String
             LeaderboardEntry { position: 5, player_short: "CANTLAY".into(),   score: "-3".into()  },
         ],
     };
+    // Off-season variant: empty leaderboard → the "OFFSEASON" card.
+    let offseason = GolfData { leaderboard: vec![], ..data.clone() };
+    let mut toggle = false;
     loop {
-        r.render(matrix, &data).await.map_err(|e| e.to_string())?;
+        let d = if toggle { &offseason } else { &data };
+        toggle = !toggle;
+        r.render(matrix, d).await.map_err(|e| e.to_string())?;
     }
 }
 
@@ -734,7 +753,8 @@ async fn preview_f1(matrix: &mut RGBMatrix, fonts: &Path) -> Result<(), String> 
     let mut r = F1Matrix::with_fonts_async(F1Fonts {
         body: fonts.join("04B_03B_.TTF"),
     })
-    .await?;
+    .await?
+    .with_offseason(true);
     let data = F1Data {
         season: "2026".into(),
         next_race: Some(NextRace {
@@ -751,8 +771,13 @@ async fn preview_f1(matrix: &mut RGBMatrix, fonts: &Path) -> Result<(), String> 
             DriverStanding { position: 5, code: "HAM".into(), family_name: "Hamilton".into(),   points: 99.0  },
         ],
     };
+    // Off-season variant: no current race → the reigning-champion banner.
+    let offseason = F1Data { next_race: None, ..data.clone() };
+    let mut toggle = false;
     loop {
-        r.render(matrix, &data).await.map_err(|e| e.to_string())?;
+        let d = if toggle { &offseason } else { &data };
+        toggle = !toggle;
+        r.render(matrix, d).await.map_err(|e| e.to_string())?;
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds a `show_offseason` config toggle for sport, golf, and F1 modules, letting users hide modules that have no live data during their off-season.
- Revamps the off-season card rendering across both the RGB matrix and e-ink renderers.

## Changes
- **Config**: new `show_offseason` field wired through `registry.rs`, the `createjson` TUI schemas (`sport.rs`, `golf.rs`, `f1.rs`), and all three example configs (`ohmyoled.{json,yaml,toml}`).
- **Renderers**: updated off-season layouts in `src/lib/matrix/{sport,golf,f1}.rs` and their e-ink counterparts under `src/lib/matrix/eink/`.
- **Preview**: `src/preview.rs` exercises the new off-season paths.
- **Docs**: README updated to document the toggle.

## Test plan
- [ ] `cargo build`
- [ ] `cargo test --lib`
- [ ] `cargo run --example config_formats`
- [ ] `OHMYOLED_MATRIX_MODE=test cargo run -- --preview sport` (eyeball off-season card)

🤖 Generated with [Claude Code](https://claude.com/claude-code)