### PR TITLE
chore(release): bump version to 4.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "ohmyoled"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "ohmyoled"
-version = "4.1.0"
+version = "4.2.0"
 edition = "2021"
 default-run = "ohmyoled"
 


### PR DESCRIPTION
Bumps the workspace version to 4.2.0 ahead of the release tag.

The 4.2.0 feature work (sport off-season display, #144) is already on main; this carries the version bump that missed the previous merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)