### PR TITLE
v4.2.2 — glibc-pinned Pi binaries, e-ink post-refresh fade fix, sleep-schedule tile in the config wizard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,14 @@ permissions:
 
 jobs:
   # Cross-compile the binary for the two Raspberry Pi targets people run
-  # ohmyoled on. `cross` handles the toolchains via Docker images, so the
-  # host runner doesn't need any aarch64/armhf packages installed.
+  # ohmyoled on. We use cargo-zigbuild rather than `cross` so we can pin the
+  # *target glibc floor* explicitly (the `.2.31` suffix on the triple). Raspberry
+  # Pi OS Bullseye ships glibc 2.31; a binary built against a newer glibc (as the
+  # cross `:main` images produce — Ubuntu 24.04 / glibc 2.39) fails to load on the
+  # Pi with `version 'GLIBC_2.3x' not found`. zig's bundled clang also
+  # statically links libstdc++, so there's no `GLIBCXX_*` runtime dependency
+  # either. This same binary is later COPY'd into the release Docker image; a
+  # 2.31 floor is trivially satisfied by bookworm-slim (glibc 2.36).
   build:
     name: Build (${{ matrix.target }})
     runs-on: ubuntu-latest
@@ -33,14 +39,10 @@ jobs:
         include:
           - target: aarch64-unknown-linux-gnu
             artifact: ohmyoled-aarch64
-            cc: aarch64-linux-gnu-gcc
-            cxx: aarch64-linux-gnu-g++
-            ar: aarch64-linux-gnu-ar
+            zig_target: aarch64-linux-gnu.2.31
           - target: armv7-unknown-linux-gnueabihf
             artifact: ohmyoled-armv7
-            cc: arm-linux-gnueabihf-gcc
-            cxx: arm-linux-gnueabihf-g++
-            ar: arm-linux-gnueabihf-ar
+            zig_target: arm-linux-gnueabihf.2.31
     steps:
       - uses: actions/checkout@v4
 
@@ -49,26 +51,48 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Install cross
+      - name: Install zig
+        uses: mlugg/setup-zig@v1
+        with:
+          version: 0.13.0
+
+      - name: Install cargo-zigbuild
         uses: taiki-e/install-action@v2
         with:
-          tool: cross
+          tool: cargo-zigbuild
 
-      # No font fetch needed — Font::load_ttf is a runtime concern.
-      # CC/CXX/AR are forwarded into the cross container (via the
-      # passthrough block in Cross.toml) so rpi-led-matrix-sys's
-      # vendored Makefile builds the C++ library with the cross
-      # toolchain instead of the host x86_64 one.
+      # rpi-led-matrix-sys's build.rs shells out to `make` against the vendored
+      # rpi-rgb-led-matrix Makefile, which uses plain CC/CXX/AR. Point those at
+      # glibc-pinned `zig cc`/`zig c++`/`zig ar` wrappers so the C++ objects are
+      # compiled against the same 2.31 floor as the Rust code — otherwise they'd
+      # pull the runner's host glibc symbols and reintroduce the mismatch.
+      #
+      # cargo-zigbuild parses the `.2.31` suffix on the Rust triple for the link;
+      # its build output still lands under the un-suffixed `target/<triple>/`.
+      #
       # `--features eink` pulls in the Waveshare SPI backend alongside the
       # default `hardware` (LED panel) backend. Both deps are target-gated to
       # arm/aarch64 in ohmyoled-matrix/Cargo.toml, so the same flag is safe on
       # both Pi targets — the released binary supports LED and e-ink panels.
       - name: Build
-        env:
-          CC: ${{ matrix.cc }}
-          CXX: ${{ matrix.cxx }}
-          AR: ${{ matrix.ar }}
-        run: cross build --release --features eink --target ${{ matrix.target }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/zigbin"
+          cat > "$RUNNER_TEMP/zigbin/zcc" <<EOF
+          #!/bin/sh
+          exec zig cc -target ${{ matrix.zig_target }} "\$@"
+          EOF
+          cat > "$RUNNER_TEMP/zigbin/zcxx" <<EOF
+          #!/bin/sh
+          exec zig c++ -target ${{ matrix.zig_target }} "\$@"
+          EOF
+          cat > "$RUNNER_TEMP/zigbin/zar" <<EOF
+          #!/bin/sh
+          exec zig ar "\$@"
+          EOF
+          chmod +x "$RUNNER_TEMP/zigbin/"z*
+          export PATH="$RUNNER_TEMP/zigbin:$PATH"
+          export CC=zcc CXX=zcxx AR=zar
+          cargo zigbuild --release --features eink --target ${{ matrix.target }}.2.31
 
       - name: Stage binary
         run: cp target/${{ matrix.target }}/release/ohmyoled ${{ matrix.artifact }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -547,7 +547,7 @@ scheduler.
 | Add a new font                        | `src/sh/install.sh` + the renderer's `*Fonts` struct                   |
 | Change a shared HTTP behavior         | `src/lib/api/http.rs`                                                  |
 | Tweak the scheduler                   | `src/lib/modules/scheduler.rs`                                         |
-| Change sleep-mode behavior            | `src/lib/modules/sleep.rs` (gate + `SleepSchedule`); `SleepConfig` is a **top-level** block in `registry.rs`, parsed in `main.rs` (`SleepTopConfig`), gated in `scheduler.rs` (render loops) + `mod.rs` (`background_poll`) |
+| Change sleep-mode behavior            | `src/lib/modules/sleep.rs` (gate + `SleepSchedule`); `SleepConfig` is a **top-level** block in `registry.rs`, parsed in `main.rs` (`SleepTopConfig`), gated in `scheduler.rs` (render loops) + `mod.rs` (`background_poll`). The `-c` wizard edits it as the single-instance `sleep` tile: schema + cron/HH:MM validation in `src/createjson/sleep.rs`, top-level assembly (never under `eink.modules`) in `tui/preview.rs::attach_sleep`, un-editable `windows` preserved via `App::preserved_sleep_windows` |
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "ohmyoled"
-version = "4.2.1"
+version = "4.2.2"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "ohmyoled"
-version = "4.2.0"
+version = "4.2.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "ohmyoled"
-version = "4.2.0"
+version = "4.2.1"
 edition = "2021"
 default-run = "ohmyoled"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "ohmyoled"
-version = "4.2.1"
+version = "4.2.2"
 edition = "2021"
 default-run = "ohmyoled"
 

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,3 +1,10 @@
+# NOTE: The release workflow no longer uses `cross` — it builds with
+# cargo-zigbuild so it can pin the target glibc floor (see the `build` job in
+# .github/workflows/release.yml). The `:main` images below are Ubuntu 24.04
+# (glibc 2.39), which produce binaries that FAIL to load on Raspberry Pi OS
+# Bullseye (glibc 2.31). This file is retained only for local `cross build`
+# convenience; do not expect its binaries to run on older Pis.
+#
 # cross-rs's default Docker images for the Pi targets are based on
 # Ubuntu 16.04 (xenial) and ship gcc 5 — too old for rpi-led-matrix-sys's
 # C++ library (newer linkers reject its objects with "File in wrong

--- a/crates/ohmyoled-matrix/src/eink/hardware.rs
+++ b/crates/ohmyoled-matrix/src/eink/hardware.rs
@@ -104,6 +104,15 @@ type EpdSpi = ExclusiveDevice<Spi, NoCs, Delay>;
 /// though, so every [`FULL_REFRESH_EVERY`] updates one is promoted to a full
 /// refresh ([`update_full`]) to reset accumulated ghosting before it fades the
 /// image.
+///
+/// After every screen-change refresh the HV rails are dropped ([`power_off`]).
+/// Leaving them up keeps a DC bias (VCOM) across the panel that visibly pulls
+/// the just-developed image back toward gray within a second or two — and per
+/// Waveshare, sustained high-voltage state permanently degrades the panel.
+/// E-ink is bistable, so once powered off the image holds crisp indefinitely.
+/// The one exception is [`update_fast`] (a 1 Hz ticking tile): it keeps the
+/// rails up between ticks — each tick re-develops the frame anyway — and the
+/// dwell-ending [`update`]/[`update_full`] pays the power-off back.
 struct SevenIn5V2 {
     spi: Spi,
     rst: Out,
@@ -116,6 +125,10 @@ struct SevenIn5V2 {
     /// [`FULL_REFRESH_EVERY`] deep-clean so accumulated ghosting never fades the
     /// image. Reset by any full refresh ([`update_full`]/[`clear`]).
     partial_since_full: u32,
+    /// Whether the HV rails are up (`PowerOn` sent, no `PowerOff` since).
+    /// Registers survive a power-off, so re-powering is just `0x04` + BUSY —
+    /// no re-init needed (see [`ensure_powered`]).
+    powered: bool,
 }
 
 impl SevenIn5V2 {
@@ -132,6 +145,7 @@ impl SevenIn5V2 {
             busy,
             in_partial_mode: false,
             partial_since_full: 0,
+            powered: false,
         };
         // Full power-on setup (resolution, VCOM, TCON). Updates then switch to
         // partial mode; the first update's clear scrubs any retained image.
@@ -203,6 +217,7 @@ impl SevenIn5V2 {
         self.cmd(0x04)?; // Power on
         sleep(Duration::from_millis(100));
         self.wait_until_idle()?;
+        self.powered = true;
         self.cmd_data(0x00, &[0x1F])?; // Panel setting (KW, no rotate)
         self.cmd_data(0x61, &[0x03, 0x20, 0x01, 0xE0])?; // TRES: 800×480
         self.cmd_data(0x15, &[0x00])?; // Dual SPI off
@@ -220,8 +235,35 @@ impl SevenIn5V2 {
         self.cmd(0x04)?; // Power on
         sleep(Duration::from_millis(100));
         self.wait_until_idle()?;
+        self.powered = true;
         self.cmd_data(0xE0, &[0x02])?; // Cascade setting (fast mode)
         self.cmd_data(0xE5, &[0x6E])?; // Force temperature (fast mode)
+        Ok(())
+    }
+
+    /// Drop the HV rails (`PowerOff`, 0x02) once the refresh has developed.
+    /// The image is bistable and holds; register config survives, so the next
+    /// refresh only needs [`ensure_powered`], not a re-init. This is the
+    /// `epd.sleep()` step of the reference flow (minus deep sleep, which would
+    /// lose the registers and need a full reset to leave).
+    fn power_off(&mut self) -> Result<(), String> {
+        self.cmd(0x02)?; // Power off
+        self.wait_until_idle()?;
+        self.powered = false;
+        Ok(())
+    }
+
+    /// Bring the HV rails back up if [`power_off`] dropped them. Mirrors the
+    /// power-on step of `init`/`init_part` (0x04 + settle + BUSY handshake);
+    /// a no-op while already powered (e.g. between [`update_fast`] ticks).
+    fn ensure_powered(&mut self) -> Result<(), String> {
+        if self.powered {
+            return Ok(());
+        }
+        self.cmd(0x04)?; // Power on
+        sleep(Duration::from_millis(100));
+        self.wait_until_idle()?;
+        self.powered = true;
         Ok(())
     }
 
@@ -285,12 +327,16 @@ impl SevenIn5V2 {
         if !self.in_partial_mode {
             self.init_part()?;
             self.in_partial_mode = true;
+        } else {
+            self.ensure_powered()?;
         }
         let white = vec![0xFF; Self::FRAME_BYTES];
         self.display_partial(&white)?;
         self.display_partial(packed)?;
         self.partial_since_full += 1;
-        Ok(())
+        // The frame has developed; drop the rails so the image holds crisp
+        // instead of fading under VCOM bias during the dwell.
+        self.power_off()
     }
 
     /// Push one packed frame with a single partial refresh and **no** clear —
@@ -301,12 +347,17 @@ impl SevenIn5V2 {
         if !self.in_partial_mode {
             self.init_part()?;
             self.in_partial_mode = true;
+        } else {
+            self.ensure_powered()?;
         }
         // Count toward the deep-clean budget but never trigger it here: a
         // ticking tile (clock, countdown) calls this every second and must not
         // flash a full refresh mid-dwell. The accumulated count is paid off by
         // the next per-tile `update`, which de-ghosts the ticking tile's trail.
         self.partial_since_full = self.partial_since_full.saturating_add(1);
+        // No power_off here: the next tick is ≤1 s away and re-develops the
+        // frame, so fade never sets in; power-cycling per tick would just add
+        // latency. The dwell-ending `update`/`update_full` drops the rails.
         self.display_partial(packed)
     }
 
@@ -318,6 +369,8 @@ impl SevenIn5V2 {
         if self.in_partial_mode {
             self.init()?;
             self.in_partial_mode = false;
+        } else {
+            self.ensure_powered()?;
         }
         // Clear to white first so the fine stipple develops on a clean substrate
         // — a single transition pass can leave residual ghosting on detail-dense
@@ -327,7 +380,9 @@ impl SevenIn5V2 {
         self.display_full(packed)?;
         // A full refresh resets the panel; the ghosting budget starts over.
         self.partial_since_full = 0;
-        Ok(())
+        // The frame has developed; drop the rails so the fine stipple holds
+        // crisp instead of fading under VCOM bias during the dwell.
+        self.power_off()
     }
 
     /// Blank the panel to white with a clean full refresh. Restores full mode
@@ -339,7 +394,8 @@ impl SevenIn5V2 {
         self.in_partial_mode = false;
         self.partial_since_full = 0;
         let white = vec![0xFF; Self::FRAME_BYTES];
-        self.display_full(&white)
+        self.display_full(&white)?;
+        self.power_off()
     }
 }
 

--- a/src/config_io.rs
+++ b/src/config_io.rs
@@ -87,12 +87,31 @@ pub fn write(path: &str, value: &serde_json::Value) -> Result<(), ConfigError> {
     let contents = match fmt {
         Format::Json => serde_json::to_string_pretty(value)?,
         Format::Yaml => serde_yml::to_string(value)?,
-        Format::Toml => toml::to_string_pretty(value)?,
+        Format::Toml => toml::to_string_pretty(&strip_nulls(value))?,
     };
     std::fs::write(path, contents).map_err(|source| ConfigError::Write {
         path: path.to_string(),
         source,
     })
+}
+
+/// TOML has no null, so serializing a config with unset optionals (blank
+/// `cache_ttl_secs`, optional strings) fails with "unsupported unit type".
+/// Recursively drop null-valued object entries instead — every optional field
+/// is `#[serde(default)]`, so an omitted key loads back as the same `None`.
+pub fn strip_nulls(value: &serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Object(m) => serde_json::Value::Object(
+            m.iter()
+                .filter(|(_, v)| !v.is_null())
+                .map(|(k, v)| (k.clone(), strip_nulls(v)))
+                .collect(),
+        ),
+        serde_json::Value::Array(a) => {
+            serde_json::Value::Array(a.iter().map(strip_nulls).collect())
+        }
+        other => other.clone(),
+    }
 }
 
 fn sniff(contents: &str) -> Option<serde_json::Value> {
@@ -162,5 +181,23 @@ mod tests {
             assert_eq!(parsed, v);
             let _ = std::fs::remove_file(&path);
         }
+    }
+
+    #[test]
+    fn toml_write_drops_null_optionals() {
+        // TOML can't hold nulls; unset optionals are dropped on write and load
+        // back as `None` through the sections' serde defaults.
+        let tmp = std::env::temp_dir().join("ohmyoled_cfgio_nulls.toml");
+        let path = tmp.to_str().unwrap();
+        let v = serde_json::json!({
+            "time": {"run": true, "cache_ttl_secs": null},
+            "sleep": {"enabled": true, "start": null, "end": null}
+        });
+        write(path, &v).expect("toml write with nulls succeeds");
+        let parsed = load(path).unwrap();
+        assert_eq!(parsed["time"]["run"], serde_json::json!(true));
+        assert!(parsed["time"].get("cache_ttl_secs").is_none());
+        assert_eq!(parsed["sleep"]["enabled"], serde_json::json!(true));
+        let _ = std::fs::remove_file(&tmp);
     }
 }

--- a/src/createjson/mod.rs
+++ b/src/createjson/mod.rs
@@ -7,6 +7,7 @@ pub mod iss;
 pub mod launch;
 pub mod pihole;
 pub mod quake;
+pub mod sleep;
 pub mod sport;
 pub mod stock;
 pub mod time;

--- a/src/createjson/sleep.rs
+++ b/src/createjson/sleep.rs
@@ -1,0 +1,198 @@
+//! Sleep-mode tile for the config builder — the top-level `sleep` block.
+//!
+//! Unlike the module tiles, `sleep` is **target-independent and top-level**:
+//! it never nests under `eink.modules`, there is at most one instance, and it
+//! carries `enabled` instead of `run`. The assembly layer
+//! (`tui::preview::sleep_value`) handles that placement; this module owns the
+//! schema + the cron/window validation so a wizard-written schedule can't be
+//! rejected by the daemon at startup (`SleepSchedule::from_config` applies the
+//! same rules).
+//!
+//! The cron-anchored `windows` list (objects of `{at, for_mins}`) doesn't fit
+//! the flat form engine, so the wizard doesn't edit it — a loaded config's
+//! `windows` are preserved verbatim across a round-trip instead.
+
+use crate::createjson::tui::field::{FieldDef, FieldKind};
+use chrono::NaiveTime;
+use croner::Cron;
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+
+/// The top-level `sleep` block, mirroring `registry::SleepConfig`. `windows`
+/// stays an opaque `Value` list: the wizard preserves it rather than editing it.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SleepOptions {
+    pub enabled: bool,
+    #[serde(default)]
+    pub sleep: Option<String>,
+    #[serde(default)]
+    pub wake: Option<String>,
+    #[serde(default)]
+    pub start: Option<String>,
+    #[serde(default)]
+    pub end: Option<String>,
+    #[serde(default)]
+    pub windows: Vec<serde_json::Value>,
+}
+
+impl Default for SleepOptions {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            sleep: Some("0 22 * * *".into()),
+            wake: Some("0 7 * * *".into()),
+            start: None,
+            end: None,
+            windows: Vec::new(),
+        }
+    }
+}
+
+/// Field schema. `id` MUST match the serde field name — the value is
+/// round-tripped through [`SleepOptions`] on save, so a typo'd id is dropped.
+pub fn fields() -> Vec<FieldDef> {
+    vec![
+        FieldDef::new(
+            "enabled",
+            "Enabled",
+            "Master switch — off keeps the schedule but never sleeps.",
+            FieldKind::Bool { default: true },
+        ),
+        FieldDef::new(
+            "sleep",
+            "Sleep cron",
+            "Cron that ENTERS sleep, e.g. '0 22 * * *' (pairs with wake; blank = unused).",
+            FieldKind::OptionalText { default: "0 22 * * *" },
+        ),
+        FieldDef::new(
+            "wake",
+            "Wake cron",
+            "Cron that WAKES, e.g. '0 7 * * *' (pairs with sleep cron).",
+            FieldKind::OptionalText { default: "0 7 * * *" },
+        ),
+        FieldDef::new(
+            "start",
+            "Window start (HH:MM)",
+            "Plain clock window start, e.g. '22:00' (pairs with end; wraps midnight).",
+            FieldKind::OptionalText { default: "" },
+        ),
+        FieldDef::new(
+            "end",
+            "Window end (HH:MM)",
+            "Plain clock window end, e.g. '07:00' (pairs with start).",
+            FieldKind::OptionalText { default: "" },
+        ),
+    ]
+}
+
+/// A set optional string — `None`, blank, and the legacy `"null"` literal all
+/// count as unset (matching `null_string_as_none` in the daemon's parser).
+fn set_str(v: &Option<String>) -> Option<&str> {
+    v.as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty() && !s.eq_ignore_ascii_case("null"))
+}
+
+/// Validate the schedule the same way `SleepSchedule::from_config` does:
+/// `sleep`/`wake` must pair and parse as cron; `start`/`end` must pair and
+/// parse as `HH:MM`. Returns `(field id, message)` errors for the form UI.
+pub fn validate(opts: &SleepOptions) -> Vec<(String, String)> {
+    let mut errs = Vec::new();
+
+    let mut check_cron = |id: &str, expr: Option<&str>| {
+        if let Some(e) = expr {
+            if let Err(err) = Cron::from_str(e) {
+                errs.push((id.to_string(), format!("invalid cron '{e}': {err}")));
+            }
+        }
+    };
+    let (sleep, wake) = (set_str(&opts.sleep), set_str(&opts.wake));
+    check_cron("sleep", sleep);
+    check_cron("wake", wake);
+    if sleep.is_some() != wake.is_some() {
+        errs.push((
+            "sleep".to_string(),
+            "sleep and wake crons must both be set (or both blank)".to_string(),
+        ));
+    }
+
+    let mut check_time = |id: &str, t: Option<&str>| {
+        if let Some(s) = t {
+            if NaiveTime::parse_from_str(s, "%H:%M").is_err() {
+                errs.push((id.to_string(), format!("'{s}' is not HH:MM")));
+            }
+        }
+    };
+    let (start, end) = (set_str(&opts.start), set_str(&opts.end));
+    check_time("start", start);
+    check_time("end", end);
+    if start.is_some() != end.is_some() {
+        errs.push((
+            "start".to_string(),
+            "start and end must both be set (or both blank)".to_string(),
+        ));
+    }
+
+    errs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn opts() -> SleepOptions {
+        SleepOptions {
+            enabled: true,
+            sleep: None,
+            wake: None,
+            start: None,
+            end: None,
+            windows: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn default_cron_pair_validates() {
+        assert!(validate(&SleepOptions::default()).is_empty());
+    }
+
+    #[test]
+    fn half_pairs_are_errors() {
+        let half = SleepOptions { sleep: Some("0 22 * * *".into()), ..opts() };
+        assert!(!validate(&half).is_empty());
+        let half = SleepOptions { start: Some("22:00".into()), ..opts() };
+        assert!(!validate(&half).is_empty());
+    }
+
+    #[test]
+    fn malformed_cron_and_time_are_errors() {
+        let bad = SleepOptions {
+            sleep: Some("not a cron".into()),
+            wake: Some("0 7 * * *".into()),
+            ..opts()
+        };
+        assert!(validate(&bad).iter().any(|(id, _)| id == "sleep"));
+        let bad = SleepOptions {
+            start: Some("25:99".into()),
+            end: Some("07:00".into()),
+            ..opts()
+        };
+        assert!(validate(&bad).iter().any(|(id, _)| id == "start"));
+    }
+
+    #[test]
+    fn null_literal_and_blank_count_as_unset() {
+        let v = SleepOptions {
+            sleep: Some("null".into()),
+            wake: Some("".into()),
+            ..opts()
+        };
+        assert!(validate(&v).is_empty(), "legacy 'null' strings are unset");
+    }
+
+    #[test]
+    fn empty_schedule_is_valid() {
+        // The daemon treats an all-blank schedule as a no-op, not an error.
+        assert!(validate(&opts()).is_empty());
+    }
+}

--- a/src/createjson/tui/app.rs
+++ b/src/createjson/tui/app.rs
@@ -105,10 +105,11 @@ pub struct App {
     pub should_quit: bool,
     /// `Some` on save (config + chosen format), `None` while running / on quit.
     pub result: Option<(Value, ConfigFormat)>,
-    /// Top-level `sleep` block carried over from a loaded config. The wizard
-    /// doesn't edit sleep mode, but it must not drop it on re-save — so it's
-    /// stashed here and re-emitted verbatim by [`super::preview::build_value`].
-    pub preserved_sleep: Option<Value>,
+    /// The `sleep.windows` list carried over from a loaded config. The wizard
+    /// edits the rest of the sleep block through its tile, but the
+    /// cron-anchored window objects don't fit the flat form engine — so they're
+    /// stashed here and re-attached by [`super::preview::build_value`].
+    pub preserved_sleep_windows: Option<Value>,
 }
 
 impl App {
@@ -122,12 +123,28 @@ impl App {
             .map(detect_target)
             .unwrap_or(Target::Matrix);
         let target_form = build_target_form(target, existing.as_ref());
-        let instances = existing
+        let mut instances = existing
             .as_ref()
             .map(|v| load_instances(v, target))
             .unwrap_or_default();
         let fmt = initial_fmt.unwrap_or(ConfigFormat::Json);
-        let preserved_sleep = existing.as_ref().and_then(|v| v.get("sleep").cloned());
+        // `sleep` is a top-level, target-independent block — loaded here rather
+        // than in the SECTION_KEYS scan (which, on the eink target, only looks
+        // under `eink.modules`). The un-editable `windows` list is stashed so a
+        // round-trip can't drop it.
+        let mut preserved_sleep_windows = None;
+        if let Some(block) = existing.as_ref().and_then(|v| v.get("sleep")) {
+            if block.is_object() {
+                instances.push(Instance {
+                    kind: "sleep",
+                    form: form_module::value_to_form("sleep", &normalize_nulls(block)),
+                });
+                preserved_sleep_windows = block
+                    .get("windows")
+                    .filter(|w| w.as_array().is_some_and(|a| !a.is_empty()))
+                    .cloned();
+            }
+        }
         let (screen, status) = if existing.is_some() {
             (
                 Screen::Modules,
@@ -154,7 +171,7 @@ impl App {
             status,
             should_quit: false,
             result: None,
-            preserved_sleep,
+            preserved_sleep_windows,
         }
     }
 
@@ -286,6 +303,21 @@ fn load_instances(value: &Value, target: Target) -> Vec<Instance> {
         }
     }
     out
+}
+
+/// Replace the legacy `"null"` string literals (what the old builder wrote for
+/// unset optionals) with real JSON nulls, so loaded sleep fields show blank in
+/// the form instead of the word "null".
+fn normalize_nulls(block: &Value) -> Value {
+    let mut v = block.clone();
+    if let Value::Object(m) = &mut v {
+        for val in m.values_mut() {
+            if val.as_str().is_some_and(|s| s.eq_ignore_ascii_case("null")) {
+                *val = Value::Null;
+            }
+        }
+    }
+    v
 }
 
 /// Map a sport-array entry to its tile kind by the inner `sport` tag.

--- a/src/createjson/tui/event.rs
+++ b/src/createjson/tui/event.rs
@@ -138,14 +138,19 @@ fn modules_list_keys(app: &mut App, key: KeyEvent) {
             }
         }
         KeyCode::Char('a') => {
-            // Every tile may repeat — sections fold to a JSON array on save.
-            app.add_instance(kind);
-            app.inst_idx = app.instances_of(kind).len().saturating_sub(1);
-            app.status = format!(
-                "Added {} #{} — ←/→ to switch, d to remove",
-                form_module::title(kind),
-                app.inst_idx + 1
-            );
+            // Most tiles may repeat — sections fold to a JSON array on save.
+            // `sleep` is a single top-level object, so exactly one.
+            if !form_module::allow_multi(kind) && app.kind_enabled(kind) {
+                app.status = format!("Only one {} allowed", form_module::title(kind));
+            } else {
+                app.add_instance(kind);
+                app.inst_idx = app.instances_of(kind).len().saturating_sub(1);
+                app.status = format!(
+                    "Added {} #{} — ←/→ to switch, d to remove",
+                    form_module::title(kind),
+                    app.inst_idx + 1
+                );
+            }
         }
         KeyCode::Char('d') if inst_count > 0 => {
             app.remove_active_instance();

--- a/src/createjson/tui/form_module.rs
+++ b/src/createjson/tui/form_module.rs
@@ -9,12 +9,15 @@
 
 use super::field::{FieldDef, FieldKind, Form};
 use crate::createjson::{
-    aurora, f1, flights, golf, hass, iss, launch, pihole, quake, sport, stock, time, weather,
+    aurora, f1, flights, golf, hass, iss, launch, pihole, quake, sleep, sport, stock, time,
+    weather,
 };
 use serde_json::{json, Map, Value};
 
 /// Selectable tile kinds shown on the Modules screen, in display order, as
-/// `(kind id, menu label)`. Same set for both display targets.
+/// `(kind id, menu label)`. Same set for both display targets. `sleep` is the
+/// one non-module tile: single-instance, `enabled` instead of `run`, and it
+/// always assembles at the config top level (never under `eink.modules`).
 pub const TILE_KINDS: &[(&str, &str)] = &[
     ("time", "Time"),
     ("weather", "Weather"),
@@ -29,7 +32,14 @@ pub const TILE_KINDS: &[(&str, &str)] = &[
     ("launch", "Launch"),
     ("hass", "Home Assistant"),
     ("pihole", "Pi-hole"),
+    ("sleep", "Sleep Schedule"),
 ];
+
+/// Whether a tile kind may have several instances (folded to a JSON array).
+/// `sleep` is a single top-level object in the registry, so exactly one.
+pub fn allow_multi(kind: &str) -> bool {
+    kind != "sleep"
+}
 
 /// Menu label for a tile kind.
 pub fn title(kind: &str) -> &'static str {
@@ -55,6 +65,7 @@ pub fn config_key(kind: &str) -> &'static str {
         "launch" => "launch",
         "hass" => "hass",
         "pihole" => "pihole",
+        "sleep" => "sleep",
         _ => "",
     }
 }
@@ -75,14 +86,16 @@ pub fn fields(kind: &str) -> Vec<FieldDef> {
         "launch" => launch::fields(),
         "hass" => hass::fields(),
         "pihole" => pihole::fields(),
+        "sleep" => sleep::fields(),
         _ => Vec::new(),
     }
 }
 
 /// A fresh default form for a tile kind, with any dynamic options populated
-/// (sport's team list).
+/// (sport's team list). `sleep` carries its own `enabled` switch, so it's the
+/// one kind that doesn't get the implicit `run: true`.
 pub fn default_form(kind: &str) -> Form {
-    let mut form = Form::from_defs(fields(kind), true);
+    let mut form = Form::from_defs(fields(kind), kind != "sleep");
     init_dynamic(kind, &mut form);
     form
 }
@@ -129,6 +142,16 @@ pub fn section_to_value(kind: &str, form: &Form) -> Result<Value, Vec<(String, S
     // shape physically can't drift from the struct (unknown keys dropped,
     // renames applied). Value-native sport flavours pass through untouched.
     let v = canonicalize(kind, v).map_err(|e| vec![(kind.to_string(), e)])?;
+    // Sleep gets the daemon's own schedule validation (cron syntax, HH:MM,
+    // pairing rules) so a wizard-written config can't fail at startup.
+    if kind == "sleep" {
+        let opts: sleep::SleepOptions = serde_json::from_value(v.clone())
+            .map_err(|e| vec![("sleep".to_string(), e.to_string())])?;
+        let errs = sleep::validate(&opts);
+        if !errs.is_empty() {
+            return Err(errs);
+        }
+    }
     let mut map = match v {
         Value::Object(m) => m,
         other => return Ok(other),
@@ -172,6 +195,7 @@ fn canonicalize(kind: &str, v: Value) -> Result<Value, String> {
         "launch" => roundtrip!(launch::LaunchOptions),
         "hass" => roundtrip!(hass::HassOptions),
         "pihole" => roundtrip!(pihole::PiholeOptions),
+        "sleep" => roundtrip!(sleep::SleepOptions),
         _ => Ok(v),
     }
 }

--- a/src/createjson/tui/preview.rs
+++ b/src/createjson/tui/preview.rs
@@ -49,7 +49,7 @@ fn build_matrix(app: &App, strict: bool, errs: &mut Vec<(String, String)>) -> Va
             map.insert(key.to_string(), v);
         }
     }
-    preserve_sleep(app, &mut map);
+    attach_sleep(app, &mut map, strict, errs);
     Value::Object(map)
 }
 
@@ -69,18 +69,32 @@ fn build_eink(app: &App, strict: bool, errs: &mut Vec<(String, String)>) -> Valu
     block.insert("modules".to_string(), Value::Object(modules));
     let mut root = Map::new();
     root.insert("eink".to_string(), Value::Object(block));
-    preserve_sleep(app, &mut root);
+    attach_sleep(app, &mut root, strict, errs);
     Value::Object(root)
 }
 
-/// Re-emit a `sleep` block carried over from a loaded config. The wizard never
-/// edits sleep mode, so this just keeps it from being silently dropped on save
-/// (works for either target, since `sleep` is a top-level, target-independent
-/// block).
-fn preserve_sleep(app: &App, map: &mut Map<String, Value>) {
-    if let Some(sleep) = &app.preserved_sleep {
-        map.insert("sleep".to_string(), sleep.clone());
+/// Serialize the sleep tile (if enabled) into the config root. `sleep` is a
+/// top-level, target-independent block, so it never joins the SECTION_ORDER
+/// walk (which nests under `eink.modules` on the eink target). The
+/// cron-anchored `windows` list carried from a loaded config is re-attached
+/// here — the wizard doesn't edit it, but it must survive a round-trip.
+fn attach_sleep(app: &App, map: &mut Map<String, Value>, strict: bool, errs: &mut Vec<(String, String)>) {
+    let Some(inst) = app.instances.iter().find(|i| i.kind == "sleep") else {
+        return;
+    };
+    let mut v = match form_module::section_to_value("sleep", &inst.form) {
+        Ok(v) => v,
+        Err(mut e) => {
+            if strict {
+                errs.append(&mut e);
+            }
+            inst.form.to_value_lossy()
+        }
+    };
+    if let (Value::Object(m), Some(w)) = (&mut v, &app.preserved_sleep_windows) {
+        m.insert("windows".to_string(), w.clone());
     }
+    map.insert("sleep".to_string(), v);
 }
 
 /// Serialize the active target form (matrix options or eink-block scalars).
@@ -154,9 +168,12 @@ pub fn render_string(value: &Value, fmt: ConfigFormat) -> String {
             serde_yml::to_string(value).unwrap_or_else(|e| format!("# yaml: {e}"))
         }
         ConfigFormat::Toml => {
-            // TOML can't represent some shapes (e.g. a top-level null); show an
-            // inline comment rather than panicking.
-            toml::to_string_pretty(value).unwrap_or_else(|e| format!("# toml: {e}"))
+            // TOML has no null — unset optionals are dropped (they load back as
+            // `None` via serde defaults), matching `config_io::write`. Any
+            // other unrepresentable shape shows an inline comment rather than
+            // panicking.
+            toml::to_string_pretty(&crate::config_io::strip_nulls(value))
+                .unwrap_or_else(|e| format!("# toml: {e}"))
         }
     }
 }
@@ -245,25 +262,100 @@ mod tests {
     }
 
     #[test]
-    fn preserves_loaded_sleep_block_on_both_targets() {
+    fn round_trips_loaded_sleep_block_on_both_targets() {
         let cfg = json!({
             "matrix_options": {"chain_length": 1},
             "time": {"run": true, "color": [255, 255, 255]},
             "sleep": {"enabled": true, "sleep": "0 22 * * *", "wake": "0 7 * * *"}
         });
-        // Matrix target round-trips the sleep block verbatim.
-        let app = App::new(Some(cfg.clone()), None);
+        // Matrix target: the block loads into the sleep tile and re-emits at
+        // the top level (plus the struct's remaining keys at their defaults).
+        let app = App::new(Some(cfg), None);
         let v = preview_value(&app);
-        assert_eq!(v["sleep"], cfg["sleep"]);
+        assert_eq!(v["sleep"]["enabled"], json!(true));
+        assert_eq!(v["sleep"]["sleep"], json!("0 22 * * *"));
+        assert_eq!(v["sleep"]["wake"], json!("0 7 * * *"));
+        assert!(v["sleep"].get("run").is_none(), "sleep uses enabled, not run");
 
-        // And an eink config keeps it too (top-level, target-independent).
+        // And an eink config keeps it top-level (never under eink.modules).
         let eink_cfg = json!({
             "eink": {"enabled": true, "model": "7in5_v2", "modules": {"time": {"run": true}}},
             "sleep": {"enabled": true, "start": "22:00", "end": "07:00"}
         });
-        let app = App::new(Some(eink_cfg.clone()), None);
+        let app = App::new(Some(eink_cfg), None);
         let v = preview_value(&app);
-        assert_eq!(v["sleep"], eink_cfg["sleep"]);
+        assert_eq!(v["sleep"]["start"], json!("22:00"));
+        assert_eq!(v["sleep"]["end"], json!("07:00"));
+        assert!(v["eink"]["modules"].get("sleep").is_none());
+    }
+
+    #[test]
+    fn wizard_added_sleep_tile_emits_top_level_on_both_targets() {
+        for target in [Target::Matrix, Target::Eink] {
+            let mut app = App::new(None, None);
+            app.target = target;
+            app.rebuild_target_form();
+            app.instances.push(super::super::app::Instance {
+                kind: "sleep",
+                form: form_module::default_form("sleep"),
+            });
+            let v = preview_value(&app);
+            // Default form = enabled cron pair.
+            assert_eq!(v["sleep"]["enabled"], json!(true), "on {target:?}");
+            assert_eq!(v["sleep"]["sleep"], json!("0 22 * * *"));
+            assert_eq!(v["sleep"]["wake"], json!("0 7 * * *"));
+            if target.is_eink() {
+                assert!(v["eink"]["modules"].get("sleep").is_none());
+            }
+        }
+    }
+
+    #[test]
+    fn preserves_unedited_sleep_windows_across_round_trip() {
+        let cfg = json!({
+            "matrix_options": {"chain_length": 1},
+            "sleep": {
+                "enabled": true,
+                "windows": [{"at": "0 13 * * 6,0", "for_mins": 120}]
+            }
+        });
+        let app = App::new(Some(cfg.clone()), None);
+        let v = preview_value(&app);
+        assert_eq!(v["sleep"]["windows"], cfg["sleep"]["windows"]);
+    }
+
+    #[test]
+    fn legacy_null_literals_load_as_blank_and_reemit_null() {
+        // The --init-config starter writes "null" strings for unset optionals;
+        // they must not surface as the literal word in the form or the output.
+        let cfg = json!({
+            "matrix_options": {"chain_length": 1},
+            "sleep": {"enabled": false, "sleep": "null", "wake": "null",
+                       "start": "null", "end": "null", "windows": []}
+        });
+        let app = App::new(Some(cfg), None);
+        let v = preview_value(&app);
+        assert_eq!(v["sleep"]["enabled"], json!(false));
+        assert!(v["sleep"]["sleep"].is_null());
+        assert!(v["sleep"]["start"].is_null());
+    }
+
+    #[test]
+    fn invalid_sleep_cron_fails_strict_save() {
+        let mut app = App::new(None, None);
+        app.instances.push(super::super::app::Instance {
+            kind: "sleep",
+            form: form_module::default_form("sleep"),
+        });
+        // Corrupt the sleep cron field.
+        let form = &mut app.instances.last_mut().unwrap().form;
+        let idx = form.defs.iter().position(|d| d.id == "sleep").unwrap();
+        form.values[idx] =
+            crate::createjson::tui::field::FieldValue::Input(tui_input::Input::new(
+                "not a cron".into(),
+            ));
+        let err = build_value(&app, true).unwrap_err();
+        assert!(err.iter().any(|(id, _)| id == "sleep"), "got {err:?}");
     }
 
     #[test]
@@ -273,5 +365,20 @@ mod tests {
             let s = render_string(&v, fmt);
             assert!(!s.is_empty());
         }
+    }
+
+    #[test]
+    fn toml_render_survives_null_optionals() {
+        // Blank optionals (cache_ttl_secs, sleep start/end) emit JSON nulls,
+        // which TOML can't represent — they must be dropped, not error out.
+        let v = json!({
+            "time": {"run": true, "cache_ttl_secs": null},
+            "sleep": {"enabled": true, "sleep": "0 22 * * *", "wake": "0 7 * * *",
+                       "start": null, "end": null, "windows": []}
+        });
+        let s = render_string(&v, ConfigFormat::Toml);
+        assert!(!s.starts_with("# toml:"), "toml render errored: {s}");
+        assert!(s.contains("enabled = true"));
+        assert!(!s.contains("cache_ttl_secs"), "null keys should be dropped");
     }
 }

--- a/src/lib/matrix/sport.rs
+++ b/src/lib/matrix/sport.rs
@@ -14,7 +14,9 @@
 //!
 //! Logos are fetched on first render via `reqwest`, decoded with the `image`
 //! crate, resized to 16×16 with `Lanczos3`, and cached in-memory for the life
-//! of the renderer.
+//! of the renderer. Processed crests are also written to an on-disk cache
+//! (`$XDG_CACHE_HOME/ohmyoled/logos/`, falling back to `$HOME/.cache` then
+//! `/tmp`) so a restart is network-free — team badges never change.
 //!
 //! Middle-line color: green ⇐ home winning, red ⇐ home losing, white ⇐ tied
 //! or scheduled. Off-season is skipped by default; set `show_offseason: true`
@@ -509,8 +511,46 @@ fn middle_line_color(ng: &NextGame, line_idx: usize) -> Color {
     }
 }
 
-/// HTTP fetch + image decode + resize to `LOGO_SIZE × LOGO_SIZE`.
+/// On-disk cache directory for processed logos. Honors `XDG_CACHE_HOME`, then
+/// `$HOME/.cache`, then `/tmp`. Team logos never change, so once a processed
+/// crest is written here it's reused across restarts with no network at all.
+/// Shared location with the e-ink renderer; the size in the key keeps the
+/// 16px matrix crest from colliding with the 120px e-ink one.
+fn logo_cache_dir() -> PathBuf {
+    let base = std::env::var_os("XDG_CACHE_HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".cache")))
+        .unwrap_or_else(|| PathBuf::from("/tmp"));
+    base.join("ohmyoled").join("logos")
+}
+
+/// Stable cache path for a logo URL at the current size. `DefaultHasher::new()`
+/// is fixed-seed (not `RandomState`), so the name is deterministic across runs.
+fn logo_cache_path(url: &str) -> PathBuf {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    url.hash(&mut h);
+    LOGO_SIZE.hash(&mut h);
+    logo_cache_dir().join(format!("{:016x}.png", h.finish()))
+}
+
+/// Load a processed logo: disk cache first (static, so a hit means zero
+/// network), otherwise HTTP fetch → decode → resize to `LOGO_SIZE × LOGO_SIZE`,
+/// then write it back to disk so every subsequent run is a disk hit.
 async fn fetch_logo(url: &str) -> Result<RgbImage, String> {
+    let path = logo_cache_path(url);
+
+    // Disk hit — reuse the already-processed crest, no network.
+    let read_path = path.clone();
+    if let Ok(Ok(img)) = tokio::task::spawn_blocking(move || {
+        image::open(&read_path).map(|i| i.to_rgb8())
+    })
+    .await
+    {
+        log::debug!("sport: logo disk-cache hit for {url}");
+        return Ok(img);
+    }
+
     let bytes = shared_client()
         .get(url)
         .send()
@@ -522,9 +562,22 @@ async fn fetch_logo(url: &str) -> Result<RgbImage, String> {
         .await
         .map_err(|e| format!("body: {e}"))?;
     let owned = bytes.to_vec();
-    tokio::task::spawn_blocking(move || decode_and_resize(&owned))
-        .await
-        .map_err(|e| format!("decode task panicked: {e}"))?
+    tokio::task::spawn_blocking(move || {
+        let out = decode_and_resize(&owned)?;
+        // Persist the processed crest (best-effort — a cache write failure must
+        // never fail the render; we just re-fetch next time).
+        if let Some(dir) = path.parent() {
+            let saved = std::fs::create_dir_all(dir)
+                .map_err(|e| e.to_string())
+                .and_then(|_| out.save(&path).map_err(|e| e.to_string()));
+            if let Err(e) = saved {
+                log::debug!("sport: logo cache write failed ({}): {e}", path.display());
+            }
+        }
+        Ok(out)
+    })
+    .await
+    .map_err(|e| format!("decode task panicked: {e}"))?
 }
 
 fn decode_and_resize(bytes: &[u8]) -> Result<RgbImage, String> {


### PR DESCRIPTION
## Summary
Fixes the broken v4.2.0 release binaries, fixes the e-ink post-refresh fade, adds a sleep-schedule tile to the `-c` wizard, and cuts **v4.2.2**.

## Release binaries (glibc)
The standalone `ohmyoled-aarch64` / `ohmyoled-armv7` artifacts from v4.2.0 fail to load on Raspberry Pi OS Bullseye (glibc 2.31):

```
libc.so.6: version `GLIBC_2.32' not found
libstdc++.so.6: version `GLIBCXX_3.4.29' not found
```

They were cross-compiled with `cross`'s `:main` images (Ubuntu 24.04 / glibc 2.39). Containerized runs are unaffected (bookworm-slim ships its own 2.36 libc); only the bare-metal artifact borrows the host's glibc.

- **`release.yml`**: swap the `build` job from `cross` → **cargo-zigbuild**, pinning the target glibc floor with the `.2.31` triple suffix. zig's clang builds the vendored `rpi-rgb-led-matrix` C++ lib via glibc-pinned `CC/CXX/AR` wrappers and statically links libstdc++.
- **Verified locally** (this devcontainer is arm64) for both targets: floor at **GLIBC_2.30**, **no `GLIBCXX` dependency**, no `libstdc++.so.6` in `NEEDED`. Binary runs.
- **`Cross.toml`**: retained for local `cross` use, with a note that CI no longer uses it and its `:main` binaries won't run on older Pis.
- The same fixed binary flows into `Dockerfile.release`; a 2.31 floor is trivially satisfied by bookworm-slim.

## E-ink: image faded seconds after a full refresh
The 7in5_v2 driver never sent `PowerOff` (0x02), leaving the HV rails/VCOM biased through the whole dwell. A freshly developed frame visibly washed out to gray within a second — worst on the `show_full` world maps (ISS/aurora/quake), whose fine stipple then sat faded for the full 60 s dwell — and per Waveshare, sustained high-voltage state permanently degrades the panel.

- Rails now drop after every screen-change refresh (`update`/`update_full`/`clear`) and re-power lazily — registers survive a power-off, so resume is just `PowerOn` + BUSY, no re-init.
- The 1 Hz ticking path (`update_fast`) keeps the rails up between ticks (each tick redraws before fade can set in); the dwell-ending update pays the power-off back.
- Sleep-mode blanking now also leaves the panel powered off overnight.

## Config wizard: sleep-schedule tile + TOML fix
- The top-level `sleep` block is now editable in the `-c` TUI (single-instance tile: enabled switch, sleep/wake cron pair, HH:MM window) instead of preserve-verbatim. Saves run the daemon's own validation (croner syntax, HH:MM parsing, pairing rules) so a wizard-written schedule can't be rejected at startup. Assembly stays at the config top level on both targets — never under `eink.modules` — and the un-editable cron-anchored `windows` list survives round-trips. Legacy `"null"` literals load as blank fields.
- **TOML save fix**: saving as TOML failed with "unsupported unit type" whenever an optional was blank (the default — every tile emits `cache_ttl_secs: null`). Null keys are now dropped for TOML (in `config_io::write` + the live preview) and load back as `None` via the sections' serde defaults.

## Also
- **`matrix/sport.rs`**: add an on-disk logo cache mirroring the e-ink renderer — processed crests written to `$XDG_CACHE_HOME/ohmyoled/logos/` (→ `$HOME/.cache` → `/tmp`) so restarts are network-free. Cache key includes the 16px size so it never collides with the e-ink 120px crests.

## Test plan
- [x] `cargo test --lib` (351) + `cargo test --bin ohmyoled` (44, incl. new sleep round-trip / validation / windows-preservation / TOML-null tests)
- [x] `cargo clippy --lib --bin ohmyoled --examples` clean; `cargo check -p ohmyoled-matrix --features eink` (hardware backend)
- [x] `cargo run --example config_formats` — all three formats parse equivalently
- [x] aarch64 + armv7 zigbuild → GLIBC_2.30 floor, no GLIBCXX
- [ ] On-panel: watch a world-map screen hold contrast through the full 60 s dwell after refresh
- [ ] CI green, then tag `v4.2.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
